### PR TITLE
hotfix: docker 빌드 컨텍스트에 FE .env 삽입하기

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,8 @@ name: cd.yml
 on:
   push:
     branches:
-      - hotfix/105-cd-pipeline-FE
+      - main
+      - develop
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

- Closes #105 


<br>

## 📝 작업 내용
> 작업한 내용을 작성해주세요.

### 문제 상황
<img width="1067" height="377" alt="image" src="https://github.com/user-attachments/assets/4df9bdde-3433-4c91-9092-1c349dc88d4e" />

프로젝트 루트에 있는 .dockerignore 파일이 .env 파일을 무시하고 있기 때문에, Docker Image 빌드 과정에서 .env를 읽지 못하는 문제 발생.

### 해결

`.dockerignore` 에서 .env를 무시하지 못하게 수정

현재 Dockerfile이 multi stage build로 작성되어있기 때문에, `.env`를 빌드 과정에서 copy해서 사용되어도 최종 빌드 이미지에는 담기지 않음.

<br>

## 🖼️ 스크린샷 (선택)

<img width="1512" height="721" alt="image" src="https://github.com/user-attachments/assets/cbe8fb3e-2674-4e76-be9f-526e9ab2ac46" />



<br>

## 테스트 및 검증 내용
> 어떻게 테스트했고, 어떤 결과를 확인했는지 적어주세요.


<br>

## 🤔 주요 고민과 해결 과정

> 작성 양식
> - [트러블 슈팅1](링크)
> 혹은 직접 작성


<br>

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

흠 근데, 빌드 속도가 너무 느리네요 Web App 하나 배포하는데 3분 가량이 소요되니...

<br>

## 🧩 참고 사항 (선택)

> 공유하고 싶은 링크나 게시글 등