### PR TITLE
Socket 재연결 로직 개선

### DIFF
--- a/apps/frontend/src/config/socket.ts
+++ b/apps/frontend/src/config/socket.ts
@@ -1,0 +1,1 @@
+export const socketBaseUrl = import.meta.env.VITE_PUBLIC_BASE_URL ?? window.location.origin

--- a/apps/frontend/src/hooks/useSocketClient.ts
+++ b/apps/frontend/src/hooks/useSocketClient.ts
@@ -23,8 +23,7 @@ export function useSocketClient({ namespace, baseUrl, autoConnect = true, autoRe
   const reconnectAttemptsRef = useRef(0)
 
   const fullUrl = useMemo(() => {
-    const origin = baseUrl ?? window.location.origin
-    return `${origin}${namespace ? `/${namespace}` : ''}`
+    return `${baseUrl}${namespace ? `/${namespace}` : ''}`
   }, [baseUrl, namespace])
 
   const [status, setStatus] = useState<SocketStatus>(autoConnect ? 'connecting' : 'disconnected')

--- a/apps/frontend/src/hooks/useYjsSocket.ts
+++ b/apps/frontend/src/hooks/useYjsSocket.ts
@@ -14,6 +14,7 @@ import type {
 import type { Rectangle, PostIt, Line } from '@/types/canvas.types'
 import { throttle } from '@/utils/throttle'
 import { useSocketClient } from '@/hooks/useSocketClient'
+import { socketBaseUrl } from '@/config/socket'
 
 interface UseYjsSocketOptions {
   roomId: string
@@ -28,8 +29,6 @@ export function useYjsSocket({ roomId, canvasId }: UseYjsSocketOptions) {
   const [lines, setLines] = useState<Line[]>([])
   const [socketId, setSocketId] = useState('unknown')
 
-  const serverUrl = import.meta.env.VITE_PUBLIC_BASE_URL ?? window.location.origin
-
   const socketRef = useRef<Socket | null>(null)
   const docRef = useRef<Y.Doc | null>(null)
   const handleSocketError = useCallback((error: Error) => {
@@ -38,7 +37,7 @@ export function useYjsSocket({ roomId, canvasId }: UseYjsSocketOptions) {
 
   const { getSocket, status } = useSocketClient({
     namespace: 'canvas',
-    baseUrl: serverUrl,
+    baseUrl: socketBaseUrl,
     onError: handleSocketError,
   })
   const isConnected = status === 'connected'

--- a/apps/frontend/src/pages/MainPage.tsx
+++ b/apps/frontend/src/pages/MainPage.tsx
@@ -5,6 +5,7 @@ import WhiteboardSection from '@/components/main/WhiteboardSection'
 import LocationListSection from '@/components/main/LocationListSection'
 import { useRoomMeta, useRoomParticipants, useRoomSocketCache } from '@/hooks/room'
 import { getOrCreateStoredUser } from '@/utils/userStorage'
+import { socketBaseUrl } from '@/config/socket'
 
 function MainPage() {
   const { slug } = useParams<{ slug: string }>()
@@ -29,8 +30,7 @@ function MainPage() {
     return null
   }
 
-  const baseUrl = import.meta.env.VITE_PUBLIC_BASE_URL ?? window.location.origin
-  const roomLink = `${baseUrl}/room/${slug}`
+  const roomLink = `${socketBaseUrl}/room/${slug}`
 
   if (!ready || !roomId) {
     return (

--- a/apps/frontend/src/pages/OnboardingPage.tsx
+++ b/apps/frontend/src/pages/OnboardingPage.tsx
@@ -4,6 +4,7 @@ import LocationStep from '@/components/onboarding/LocationStep'
 import InviteStep from '@/components/onboarding/InviteStep'
 import Header from '@/components/common/Header'
 import { createRoom } from '@/api/room'
+import { socketBaseUrl } from '@/config/socket'
 
 type OnboardingStep = 'location' | 'invite'
 
@@ -30,9 +31,8 @@ function OnboardingPage() {
         y: location.y,
         place_name: location.name,
       })
-      const baseUrl = import.meta.env.VITE_PUBLIC_BASE_URL ?? window.location.origin
       setRoomSlug(room.slug)
-      setInviteLink(`${baseUrl}/room/${room.slug}`)
+      setInviteLink(`${socketBaseUrl}/room/${room.slug}`)
       setCurrentStep('invite')
     } catch (error) {
       console.error('방 생성 실패', error)


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
> - Closes #170 


<br>

## 📝 작업 내용

- useSocketClient 중심으로 소켓 생성/재연결 정책을 통일하고 baseUrl 지원 추가
- useYjsSocket는 공통 훅을 사용하도록 이관, 재연결 시 canvas:attach 재요청 보장
- onError 콜백을 useCallback으로 고정해 소켓 재생성/요청 폭주 방지

<br>

## 🤔 주요 고민과 해결 과정

[상세 문서](https://www.notion.so/Socket-2ed37262a1798068a717ec7a9de63407?source=copy_link) 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable socket base URL applied to room and invite links for consistent links across deployments

* **Refactor**
  * Centralized socket provisioning and error handling for more consistent behavior
  * Improved real-time synchronization and lifecycle management for collaborative documents
  * Connection status exposed and used for presence/cursor updates

* **Bug Fixes**
  * Cleaner setup/teardown to reduce stray listeners and resource leaks

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->