### PR TITLE
소켓 비즈니스 로직 에러 처리

### DIFF
--- a/apps/backend/src/modules/category/dto/category.s2c.dto.ts
+++ b/apps/backend/src/modules/category/dto/category.s2c.dto.ts
@@ -8,9 +8,3 @@ export type CategoryCreatedPayload = {
 export type CategoryDeletedPayload = {
   categoryId: string
 }
-
-// [S->C] category:error
-export type CategoryErrorPayload = {
-  code: string
-  message: string
-}

--- a/apps/backend/src/modules/room/dto/room.s2c.dto.ts
+++ b/apps/backend/src/modules/room/dto/room.s2c.dto.ts
@@ -13,7 +13,7 @@ export class Participant {
   name: string
 }
 
-// [S->C] room:joined - 기존 room:state 대체
+// [S->C] room:joined
 export type RoomJoinedPayload = {
   roomId: string
   participants: Participant[]

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,13 +1,21 @@
 import { Navigate, Route, Routes } from 'react-router-dom'
 import OnboardingPage from '@/pages/OnboardingPage'
 import MainPage from '@/pages/MainPage'
+import { RoomErrorBoundary } from '@/components/error-boundary/RoomErrorBoundary'
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<Navigate to="/onboarding" replace />} />
       <Route path="/onboarding" element={<OnboardingPage />} />
-      <Route path="/room/:slug" element={<MainPage />} />
+      <Route
+        path="/room/:slug"
+        element={
+          <RoomErrorBoundary>
+            <MainPage />
+          </RoomErrorBoundary>
+        }
+      />
     </Routes>
   )
 }

--- a/apps/frontend/src/components/common/Header.tsx
+++ b/apps/frontend/src/components/common/Header.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useLocation, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { BellIcon, CogIcon, ShareVariantIcon, StarIcon } from '@/components/Icons'
 import Logo from '@/assets/images/logo.svg?react'
 import RoomInfoModal from '@/components/main/RoomInfoModal'
@@ -8,7 +8,12 @@ import type { Participant } from '@/types/domain'
 import { getParticipantColor, getParticipantInitial } from '@/utils/participant'
 import { getOrCreateStoredUser, updateStoredUserName } from '@/utils/userStorage'
 
+interface MinimalHeaderProps {
+  minimal: true
+}
+
 interface HeaderProps {
+  minimal?: false
   participants: Participant[]
   currentUserId: string
   roomLink: string
@@ -18,7 +23,33 @@ interface HeaderProps {
   onTransferOwner?: (targetUserId: string) => void
 }
 
-export default function Header({ participants, currentUserId, roomLink, onUpdateName, isOwner = false, ownerId, onTransferOwner }: HeaderProps) {
+export default function Header(props: MinimalHeaderProps | HeaderProps) {
+  const isMinimal = props.minimal === true
+
+  if (isMinimal) {
+    return (
+      <header className="flex items-center justify-between px-6 py-3 bg-white border-b border-gray-200">
+        <div className="flex items-center gap-4">
+          <Logo />
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Button variant="gray" size="icon" className="w-9 h-9">
+            <BellIcon className="w-5 h-5" />
+          </Button>
+
+          <Button variant="gray" size="icon" className="w-9 h-9">
+            <CogIcon className="w-5 h-5" />
+          </Button>
+        </div>
+      </header>
+    )
+  }
+
+  return <FullHeader {...props} />
+}
+
+function FullHeader({ participants, currentUserId, roomLink, onUpdateName, isOwner = false, ownerId, onTransferOwner }: HeaderProps) {
   const { slug } = useParams<{ slug: string }>()
   const [userName, setUserName] = useState(() => (slug ? getOrCreateStoredUser(slug).name : ''))
 
@@ -30,8 +61,6 @@ export default function Header({ participants, currentUserId, roomLink, onUpdate
     onUpdateName?.(name)
   }
   const [isRoomInfoModalOpen, setIsRoomInfoModalOpen] = useState(false)
-  const { pathname } = useLocation()
-  const isOnboarding = pathname.startsWith('/onboarding')
 
   const MAX_DISPLAY_AVATARS = 3
   // userId 기준으로 중복 제거 (같은 userId가 여러 개 있으면 첫 번째만 유지)
@@ -49,64 +78,58 @@ export default function Header({ participants, currentUserId, roomLink, onUpdate
       </div>
 
       <div className="flex items-center gap-5">
-        {!isOnboarding && (
-          <>
-            {hasParticipants && (
-              <div className="flex items-center -space-x-2">
-                {combinedParticipants.slice(0, displayCount).map(p => (
-                  <div key={p.userId} className="relative w-9 h-9 overflow-visible">
-                    <div
-                      className="w-9 h-9 rounded-full border-2 border-white flex items-center justify-center text-sm font-bold text-black overflow-hidden"
-                      style={{ backgroundColor: getParticipantColor(p.name) }}
-                    >
-                      {getParticipantInitial(p.name)}
-                    </div>
-                    {ownerId && p.userId === ownerId && (
-                      <span className="absolute -top-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-yellow-300 border border-yellow-500 shadow-sm">
-                        <StarIcon className="w-2.5 h-2.5 text-yellow-900 fill-yellow-900" />
-                      </span>
-                    )}
-                  </div>
-                ))}
-                {extraCount > 0 && (
-                  <div className="z-10 flex items-center justify-center -ml-2 border-2 border-white rounded-full w-9 h-9 bg-gray-100">
-                    <span className="text-xs font-medium text-gray-800">+{extraCount}</span>
-                  </div>
+        {hasParticipants && (
+          <div className="flex items-center -space-x-2">
+            {combinedParticipants.slice(0, displayCount).map(p => (
+              <div key={p.userId} className="relative w-9 h-9 overflow-visible">
+                <div
+                  className="w-9 h-9 rounded-full border-2 border-white flex items-center justify-center text-sm font-bold text-black overflow-hidden"
+                  style={{ backgroundColor: getParticipantColor(p.name) }}
+                >
+                  {getParticipantInitial(p.name)}
+                </div>
+                {ownerId && p.userId === ownerId && (
+                  <span className="absolute -top-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-yellow-300 border border-yellow-500 shadow-sm">
+                    <StarIcon className="w-2.5 h-2.5 text-yellow-900 fill-yellow-900" />
+                  </span>
                 )}
               </div>
+            ))}
+            {extraCount > 0 && (
+              <div className="z-10 flex items-center justify-center -ml-2 border-2 border-white rounded-full w-9 h-9 bg-gray-100">
+                <span className="text-xs font-medium text-gray-800">+{extraCount}</span>
+              </div>
             )}
-
-            {hasParticipants && <div className="w-[1px] h-6 bg-gray-200" />}
-          </>
+          </div>
         )}
 
-        <div className="flex items-center gap-3">
-          {!isOnboarding && (
-            <div className="relative">
-              <Button
-                variant="primary"
-                size="sm"
-                icon={<ShareVariantIcon className="w-[18px] h-[18px]" />}
-                onClick={() => setIsRoomInfoModalOpen(true)}
-              >
-                Share
-              </Button>
+        {hasParticipants && <div className="w-px h-6 bg-gray-200" />}
 
-              {isRoomInfoModalOpen && (
-                <RoomInfoModal
-                  onClose={() => setIsRoomInfoModalOpen(false)}
-                  userName={userName}
-                  roomLink={roomLink}
-                  participants={participants}
-                  currentUserId={currentUserId}
-                  onUpdateName={handleUpdateName}
-                  isOwner={isOwner}
-                  ownerId={ownerId}
-                  onTransferOwner={onTransferOwner}
-                />
-              )}
-            </div>
-          )}
+        <div className="flex items-center gap-3">
+          <div className="relative">
+            <Button
+              variant="primary"
+              size="sm"
+              icon={<ShareVariantIcon className="w-[18px] h-[18px]" />}
+              onClick={() => setIsRoomInfoModalOpen(true)}
+            >
+              Share
+            </Button>
+
+            {isRoomInfoModalOpen && (
+              <RoomInfoModal
+                onClose={() => setIsRoomInfoModalOpen(false)}
+                userName={userName}
+                roomLink={roomLink}
+                participants={participants}
+                currentUserId={currentUserId}
+                onUpdateName={handleUpdateName}
+                isOwner={isOwner}
+                ownerId={ownerId}
+                onTransferOwner={onTransferOwner}
+              />
+            )}
+          </div>
 
           <Button variant="gray" size="icon" className="w-9 h-9">
             <BellIcon className="w-5 h-5" />

--- a/apps/frontend/src/components/common/ToastContainer.tsx
+++ b/apps/frontend/src/components/common/ToastContainer.tsx
@@ -17,7 +17,7 @@ export function ToastContainer() {
   return (
     <div className="fixed top-32 left-1/2 -translate-x-1/2 z-80 flex flex-col gap-2">
       {toasts.map(toast => (
-        <div
+        <button
           key={toast.id}
           className={cn(
             'bg-white px-4 flex items-center gap-2 py-3 rounded-lg shadow-lg cursor-pointer',
@@ -28,7 +28,7 @@ export function ToastContainer() {
         >
           <AlertCircleIcon className={cn('size-6', toastTypeStyles[toast.type])} />
           <p className="text-base font-semibold">{toast.message}</p>
-        </div>
+        </button>
       ))}
     </div>
   )

--- a/apps/frontend/src/components/common/ToastContainer.tsx
+++ b/apps/frontend/src/components/common/ToastContainer.tsx
@@ -15,7 +15,7 @@ export function ToastContainer() {
   if (toasts.length === 0) return null
 
   return (
-    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-80 flex flex-col gap-2">
+    <div className="fixed top-32 left-1/2 -translate-x-1/2 z-80 flex flex-col gap-2">
       {toasts.map(toast => (
         <div
           key={toast.id}

--- a/apps/frontend/src/components/error-boundary/RoomErrorBoundary.tsx
+++ b/apps/frontend/src/components/error-boundary/RoomErrorBoundary.tsx
@@ -18,12 +18,16 @@ export class RoomErrorBoundary extends Component<Props, State> {
     return { error }
   }
 
-  handleReset = () => {
-    // 초기화 필요한 작업 수행
-    this.props.onResetCleanup?.()
-
-    // resetKey 증가 → children을 key로 감싸서 완전 재마운트
-    this.setState(prev => ({ error: null, resetKey: prev.resetKey + 1 }))
+  handleReset = async () => {
+    try {
+      // 초기화 필요한 작업 수행
+      await this.props.onResetCleanup?.()
+    } catch (err) {
+      console.error(err)
+    } finally {
+      // resetKey 증가 → children을 key로 감싸서 완전 재마운트
+      this.setState(prev => ({ error: null, resetKey: prev.resetKey + 1 }))
+    }
   }
 
   render() {

--- a/apps/frontend/src/components/error-boundary/RoomErrorBoundary.tsx
+++ b/apps/frontend/src/components/error-boundary/RoomErrorBoundary.tsx
@@ -1,0 +1,35 @@
+import { Component, type ReactNode } from 'react'
+import { RoomNotFoundError } from '@/types/socket-error.types'
+import ErrorPage from '@/pages/ErrorPage'
+
+type Props = { children: ReactNode }
+type State = { error: Error | null }
+
+export class RoomErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error }
+  }
+
+  handleReset = () => {
+    this.setState({ error: null })
+  }
+
+  render() {
+    const { error } = this.state
+
+    if (error instanceof RoomNotFoundError) {
+      return <ErrorPage errorType="room-not-found" onReset={this.handleReset} />
+    }
+
+    if (error) {
+      return <ErrorPage onReset={this.handleReset} />
+    }
+
+    return this.props.children
+  }
+}

--- a/apps/frontend/src/hooks/room/useRoomSocketCache.ts
+++ b/apps/frontend/src/hooks/room/useRoomSocketCache.ts
@@ -125,8 +125,15 @@ export function useRoomSocketCache() {
       queryClient.setQueryData<Category[]>(roomQueryKeys.categories(roomId), (prev = []) => prev.filter(x => x.id !== c.categoryId))
     }
 
-    const onCategoryError = () => {
-      // TODO: 사용자에게 에러 메시지 표시 (토스트 등)
+    const onCategoryError = (errorPayload: ErrorPayload) => {
+      // NOT_IN_ROOM 에러는 새로고침으로 상태 복구
+      if (errorPayload.errorType === 'NOT_IN_ROOM') {
+        window.location.reload()
+        return
+      }
+
+      // 그 외 에러는 토스트로 표시
+      showToast(errorPayload.message, 'error')
     }
 
     const onRoomError = (errorPayload: ErrorPayload) => {

--- a/apps/frontend/src/hooks/room/useRoomSocketCache.ts
+++ b/apps/frontend/src/hooks/room/useRoomSocketCache.ts
@@ -147,6 +147,12 @@ export function useRoomSocketCache() {
         return
       }
 
+      // NOT_IN_ROOM 에러는 새로고침으로 상태 복구
+      if (errorPayload.errorType === 'NOT_IN_ROOM') {
+        window.location.reload()
+        return
+      }
+
       // 그 외 에러는 토스트로 표시
       showToast(errorPayload.message, 'error')
     }

--- a/apps/frontend/src/hooks/room/useRoomSocketCache.ts
+++ b/apps/frontend/src/hooks/room/useRoomSocketCache.ts
@@ -16,7 +16,7 @@ import type {
   CategoryDeletePayload,
   ErrorPayload,
 } from '@/types/socket'
-import type { Category, Participant } from '@/types/domain'
+import type { Category, Participant, User } from '@/types/domain'
 import { useSocketClient } from '@/hooks/useSocketClient'
 import { socketBaseUrl } from '@/config/socket'
 import { useToast } from '@/hooks/useToast'
@@ -36,20 +36,31 @@ export function useRoomSocketCache() {
   const [isReady, setIsReady] = useState(false)
   const [roomId, setRoomId] = useState<string | null>(null)
   const [error, setError] = useState<Error | null>(null)
+
   const roomIdRef = useRef<string | null>(null)
-  const userInfoRef = useRef<{ userId: string; name: string } | null>(null)
+  const userInfoRef = useRef<User | null>(null)
   const shouldRejoinRef = useRef(false)
 
   // Error Boundary로 에러 전파
-  if (error) {
-    throw error
-  }
+  if (error) throw error
+
+  const handleErrorWithToast = useCallback(
+    (errorPayload: ErrorPayload) => {
+      if (errorPayload.errorType === 'NOT_IN_ROOM') {
+        window.location.reload()
+        return
+      }
+
+      showToast(errorPayload.message, 'error')
+    },
+    [showToast],
+  )
 
   useEffect(() => {
     const socket = getSocket()
     if (!socket) return
 
-    const onReady = ({ roomId, participants, categories, ownerId }: RoomJoinedPayload) => {
+    const onJoined = ({ roomId, participants, categories, ownerId }: RoomJoinedPayload) => {
       roomIdRef.current = roomId
       setRoomId(roomId)
       setIsReady(true)
@@ -70,31 +81,31 @@ export function useRoomSocketCache() {
       shouldRejoinRef.current = false
     }
 
-    const onConnected = (p: ParticipantConnectedPayload) => {
+    const onParticipantConnected = ({ socketId, userId, name }: ParticipantConnectedPayload) => {
       const roomId = roomIdRef.current
       if (!roomId) return
 
       queryClient.setQueryData<Participant[]>(roomQueryKeys.participants(roomId), (prev = []) => {
         // socketId 기준으로 중복 체크
-        if (prev.some(x => x.socketId === p.socketId)) return prev
-        return [...prev, { socketId: p.socketId, userId: p.userId, name: p.name }]
+        if (prev.some(x => x.socketId === socketId)) return prev
+        return [...prev, { socketId, userId, name }]
       })
     }
 
-    const onDisconnected = (p: ParticipantDisconnectedPayload) => {
+    const onParticipantDisconnected = ({ socketId }: ParticipantDisconnectedPayload) => {
       const roomId = roomIdRef.current
       if (!roomId) return
 
       // socketId 기준으로 삭제 (같은 userId의 다른 세션은 유지)
-      queryClient.setQueryData<Participant[]>(roomQueryKeys.participants(roomId), (prev = []) => prev.filter(x => x.socketId !== p.socketId))
+      queryClient.setQueryData<Participant[]>(roomQueryKeys.participants(roomId), (prev = []) => prev.filter(x => x.socketId !== socketId))
     }
 
-    const onNameUpdated = (p: ParticipantNameUpdatedPayload) => {
+    const onParticipantNameUpdated = ({ userId, name }: ParticipantNameUpdatedPayload) => {
       const roomId = roomIdRef.current
       if (!roomId) return
 
       queryClient.setQueryData<Participant[]>(roomQueryKeys.participants(roomId), (prev = []) =>
-        prev.map(participant => (participant.userId === p.userId ? { ...participant, name: p.name } : participant)),
+        prev.map(participant => (participant.userId === userId ? { ...participant, name } : participant)),
       )
     }
 
@@ -108,33 +119,24 @@ export function useRoomSocketCache() {
       })
     }
 
-    const onCategoryCreated = (c: CategoryCreatedPayload) => {
+    const onCategoryCreated = ({ categoryId, name }: CategoryCreatedPayload) => {
       const roomId = roomIdRef.current
       if (!roomId) return
 
       queryClient.setQueryData<Category[]>(roomQueryKeys.categories(roomId), (prev = []) => [
         ...prev,
-        { id: c.categoryId, roomId, title: c.name, orderIndex: 0, createdAt: new Date().toISOString() },
+        { id: categoryId, roomId, title: name, orderIndex: 0, createdAt: new Date().toISOString() },
       ])
     }
 
-    const onCategoryDeleted = (c: CategoryDeletedPayload) => {
+    const onCategoryDeleted = ({ categoryId }: CategoryDeletedPayload) => {
       const roomId = roomIdRef.current
       if (!roomId) return
 
-      queryClient.setQueryData<Category[]>(roomQueryKeys.categories(roomId), (prev = []) => prev.filter(x => x.id !== c.categoryId))
+      queryClient.setQueryData<Category[]>(roomQueryKeys.categories(roomId), (prev = []) => prev.filter(x => x.id !== categoryId))
     }
 
-    const onCategoryError = (errorPayload: ErrorPayload) => {
-      // NOT_IN_ROOM 에러는 새로고침으로 상태 복구
-      if (errorPayload.errorType === 'NOT_IN_ROOM') {
-        window.location.reload()
-        return
-      }
-
-      // 그 외 에러는 토스트로 표시
-      showToast(errorPayload.message, 'error')
-    }
+    const onCategoryError = (errorPayload: ErrorPayload) => handleErrorWithToast(errorPayload)
 
     const onRoomError = (errorPayload: ErrorPayload) => {
       // NOT_FOUND 에러는 Error Boundary로 전파
@@ -147,21 +149,14 @@ export function useRoomSocketCache() {
         return
       }
 
-      // NOT_IN_ROOM 에러는 새로고침으로 상태 복구
-      if (errorPayload.errorType === 'NOT_IN_ROOM') {
-        window.location.reload()
-        return
-      }
-
-      // 그 외 에러는 토스트로 표시
-      showToast(errorPayload.message, 'error')
+      handleErrorWithToast(errorPayload)
     }
 
     const onDisconnect = (reason: Socket.DisconnectReason) => {
       setRoomId(null)
       setIsReady(false)
 
-      if (reason === 'io server disconnect' || reason === 'io client disconnect') {
+      if (isHardDisconnect(reason)) {
         shouldRejoinRef.current = false
 
         const roomId = roomIdRef.current
@@ -175,12 +170,12 @@ export function useRoomSocketCache() {
       shouldRejoinRef.current = true
     }
 
-    socket.on('room:joined', onReady)
-    socket.on('room:error', onRoomError)
-    socket.on('participant:connected', onConnected)
-    socket.on('participant:disconnected', onDisconnected)
-    socket.on('participant:name_updated', onNameUpdated)
+    socket.on('room:joined', onJoined)
+    socket.on('participant:connected', onParticipantConnected)
+    socket.on('participant:disconnected', onParticipantDisconnected)
+    socket.on('participant:name_updated', onParticipantNameUpdated)
     socket.on('room:owner_transferred', onOwnerTransferred)
+    socket.on('room:error', onRoomError)
     socket.on('category:created', onCategoryCreated)
     socket.on('category:deleted', onCategoryDeleted)
     socket.on('category:error', onCategoryError)
@@ -188,22 +183,22 @@ export function useRoomSocketCache() {
     socket.on('connect', onConnect)
 
     return () => {
-      socket.off('room:joined', onReady)
-      socket.off('room:error', onRoomError)
-      socket.off('participant:connected', onConnected)
-      socket.off('participant:disconnected', onDisconnected)
-      socket.off('participant:name_updated', onNameUpdated)
+      socket.off('room:joined', onJoined)
+      socket.off('participant:connected', onParticipantConnected)
+      socket.off('participant:disconnected', onParticipantDisconnected)
+      socket.off('participant:name_updated', onParticipantNameUpdated)
       socket.off('room:owner_transferred', onOwnerTransferred)
+      socket.off('room:error', onRoomError)
       socket.off('category:created', onCategoryCreated)
       socket.off('category:deleted', onCategoryDeleted)
       socket.off('category:error', onCategoryError)
       socket.off('disconnect', onDisconnect)
       socket.off('connect', onConnect)
     }
-  }, [getSocket, queryClient, showToast])
+  }, [getSocket, queryClient, handleErrorWithToast])
 
   const joinRoom = useCallback(
-    (nextRoomId: string, user: { userId: string; name: string }) => {
+    (nextRoomId: string, user: User) => {
       connect()
 
       const socket = getSocket()
@@ -228,6 +223,8 @@ export function useRoomSocketCache() {
 
   const leaveRoom = useCallback(() => {
     const socket = getSocket()
+    if (!socket?.connected) return
+
     const roomId = roomIdRef.current
 
     shouldRejoinRef.current = false
@@ -275,17 +272,7 @@ export function useRoomSocketCache() {
   const createCategory = useCallback(
     (name: string) => {
       const socket = getSocket()
-      const currentRoomId = roomIdRef.current
-
-      if (!socket?.connected) {
-        console.warn('소켓이 연결되지 않았습니다. 카테고리를 생성할 수 없습니다.')
-        return
-      }
-
-      if (!currentRoomId) {
-        console.warn('방에 참여하지 않았습니다. 카테고리를 생성할 수 없습니다.')
-        return
-      }
+      if (!socket?.connected) return
 
       socket.emit('category:create', { name } satisfies CategoryCreatePayload)
     },
@@ -303,4 +290,8 @@ export function useRoomSocketCache() {
   )
 
   return { ready, roomId, joinRoom, leaveRoom, updateParticipantName, transferOwner, createCategory, deleteCategory }
+}
+
+function isHardDisconnect(reason: Socket.DisconnectReason) {
+  return reason === 'io server disconnect' || reason === 'io client disconnect'
 }

--- a/apps/frontend/src/pages/ErrorPage.tsx
+++ b/apps/frontend/src/pages/ErrorPage.tsx
@@ -37,7 +37,7 @@ function ErrorPage({ errorType = 'unknown', onReset }: ErrorPageProps) {
   return (
     <div className="flex flex-col h-screen bg-gray-bg">
       <Header minimal />
-      <div className="flex flex-col items-center justify-center min-h-screen bg-gray-bg px-4">
+      <div className="flex flex-1 flex-col items-center justify-center bg-gray-bg px-4">
         <div className="flex flex-col items-center text-center max-w-md">
           <div className="size-24 mb-6 rounded-full bg-primary-bg flex items-center justify-center">
             <AlertCircleIcon className="size-24 text-primary" />

--- a/apps/frontend/src/pages/ErrorPage.tsx
+++ b/apps/frontend/src/pages/ErrorPage.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/common/Button'
 import { AlertCircleIcon } from '@/components/Icons'
+import Header from '@/components/common/Header'
 
 type ErrorType = 'room-not-found' | 'unknown'
 
@@ -30,34 +31,30 @@ function ErrorPage({ errorType = 'unknown', onReset }: ErrorPageProps) {
 
   const error = errorMessages[errorType ?? 'unknown']
 
-  const handleCreateRoom = () => {
-    onReset?.()
-    navigate('/onboarding')
-  }
-
-  const handleReset = () => {
-    onReset?.()
-    navigate(0)
-  }
+  const handleCreateRoom = () => navigate('/onboarding')
+  const handleReset = () => onReset?.()
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-bg px-4">
-      <div className="flex flex-col items-center text-center max-w-md">
-        <div className="size-24 mb-6 rounded-full bg-primary-bg flex items-center justify-center">
-          <AlertCircleIcon className="size-24 text-primary" />
-        </div>
-        <h1 className="text-3xl font-bold text-black mb-2">{error.title}</h1>
-        <h3 className="text-gray text-lg mb-8">{error.description}</h3>
+    <div className="flex flex-col h-screen bg-gray-bg">
+      <Header minimal />
+      <div className="flex flex-col items-center justify-center min-h-screen bg-gray-bg px-4">
+        <div className="flex flex-col items-center text-center max-w-md">
+          <div className="size-24 mb-6 rounded-full bg-primary-bg flex items-center justify-center">
+            <AlertCircleIcon className="size-24 text-primary" />
+          </div>
+          <h1 className="text-3xl font-bold text-black mb-2">{error.title}</h1>
+          <h3 className="text-gray text-lg mb-8">{error.description}</h3>
 
-        {errorType === 'room-not-found' ? (
-          <Button onClick={handleCreateRoom} size="lg">
-            새 방 만들기
-          </Button>
-        ) : (
-          <Button onClick={handleReset} size="lg">
-            새로고침
-          </Button>
-        )}
+          {errorType === 'room-not-found' ? (
+            <Button onClick={handleCreateRoom} size="lg">
+              새 방 만들기
+            </Button>
+          ) : (
+            <Button onClick={handleReset} size="lg">
+              새로고침
+            </Button>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/apps/frontend/src/pages/ErrorPage.tsx
+++ b/apps/frontend/src/pages/ErrorPage.tsx
@@ -1,0 +1,66 @@
+import { useNavigate } from 'react-router-dom'
+import { Button } from '@/components/common/Button'
+import { AlertCircleIcon } from '@/components/Icons'
+
+type ErrorType = 'room-not-found' | 'unknown'
+
+type ErrorMessage = {
+  title: string
+  description: string
+}
+
+const errorMessages: Record<ErrorType, ErrorMessage> = {
+  'room-not-found': {
+    title: '방을 찾을 수 없습니다',
+    description: '존재하지 않거나 삭제된 방입니다.',
+  },
+  unknown: {
+    title: '오류가 발생했습니다',
+    description: '잠시 후 다시 시도해주세요.',
+  },
+}
+
+interface ErrorPageProps {
+  errorType?: ErrorType
+  onReset?: () => void
+}
+
+function ErrorPage({ errorType = 'unknown', onReset }: ErrorPageProps) {
+  const navigate = useNavigate()
+
+  const error = errorMessages[errorType ?? 'unknown']
+
+  const handleCreateRoom = () => {
+    onReset?.()
+    navigate('/onboarding')
+  }
+
+  const handleReset = () => {
+    onReset?.()
+    navigate(0)
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-bg px-4">
+      <div className="flex flex-col items-center text-center max-w-md">
+        <div className="size-24 mb-6 rounded-full bg-primary-bg flex items-center justify-center">
+          <AlertCircleIcon className="size-24 text-primary" />
+        </div>
+        <h1 className="text-3xl font-bold text-black mb-2">{error.title}</h1>
+        <h3 className="text-gray text-lg mb-8">{error.description}</h3>
+
+        {errorType === 'room-not-found' ? (
+          <Button onClick={handleCreateRoom} size="lg">
+            새 방 만들기
+          </Button>
+        ) : (
+          <Button onClick={handleReset} size="lg">
+            새로고침
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default ErrorPage

--- a/apps/frontend/src/pages/OnboardingPage.tsx
+++ b/apps/frontend/src/pages/OnboardingPage.tsx
@@ -46,7 +46,7 @@ function OnboardingPage() {
 
   return (
     <div className="flex flex-col min-h-screen bg-gray-bg">
-      <Header participants={[]} currentUserId="onboarding" roomLink="" />
+      <Header minimal />
 
       {currentStep === 'location' && <LocationStep onNext={handleLocationSelect} />}
 

--- a/apps/frontend/src/types/domain.ts
+++ b/apps/frontend/src/types/domain.ts
@@ -16,3 +16,8 @@ export type Category = {
   orderIndex: number
   createdAt: string
 }
+
+export type User = {
+  userId: string
+  name: string
+}

--- a/apps/frontend/src/types/socket-error.types.ts
+++ b/apps/frontend/src/types/socket-error.types.ts
@@ -1,0 +1,21 @@
+import type { SocketErrorType } from './socket'
+
+/**
+ * 클라이언트 소켓 에러 타입 클래스
+ */
+class SocketError extends Error {
+  readonly errorType: SocketErrorType
+
+  constructor(errorType: SocketErrorType, message: string) {
+    super(message)
+    this.name = 'SocketError'
+    this.errorType = errorType
+  }
+}
+
+export class RoomNotFoundError extends SocketError {
+  constructor(message: string = '존재하지 않거나 삭제된 방입니다.') {
+    super('NOT_FOUND', message)
+    this.name = 'RoomNotFoundError'
+  }
+}

--- a/apps/frontend/src/types/socket.ts
+++ b/apps/frontend/src/types/socket.ts
@@ -73,16 +73,10 @@ export type CategoryDeletedPayload = {
   categoryId: string
 }
 
-// [S->C] category:error
-export type CategoryErrorPayload = {
-  code: string
-  message: string
-}
-
 // 소켓 에러 타입
 export type SocketErrorType = 'NOT_FOUND' | 'NOT_IN_ROOM' | 'NOT_OWNER' | 'TARGET_NOT_FOUND' | 'INTERNAL_SERVER_ERROR' | 'CATEGORY_OVERFLOW_EXCEPTION'
 
-// [S->C] room:error
+// [S->C] room:error / category:error
 export type ErrorPayload = {
   status: 'ERROR'
   statusCode: number

--- a/apps/frontend/src/types/socket.ts
+++ b/apps/frontend/src/types/socket.ts
@@ -1,12 +1,9 @@
-import type { Participant, Category } from './domain'
+import type { Participant, Category, User } from './domain'
 
 // [C->S] room:join
 export type RoomJoinPayload = {
   roomId: string
-  user: {
-    userId: string
-    name: string
-  }
+  user: User
 }
 
 // [S->C] room:joined

--- a/apps/frontend/src/types/socket.ts
+++ b/apps/frontend/src/types/socket.ts
@@ -78,3 +78,16 @@ export type CategoryErrorPayload = {
   code: string
   message: string
 }
+
+// 소켓 에러 타입
+export type SocketErrorType = 'NOT_FOUND' | 'NOT_IN_ROOM' | 'NOT_OWNER' | 'TARGET_NOT_FOUND' | 'INTERNAL_SERVER_ERROR' | 'CATEGORY_OVERFLOW_EXCEPTION'
+
+// [S->C] room:error
+export type ErrorPayload = {
+  status: 'ERROR'
+  statusCode: number
+  errorType: SocketErrorType
+  message: string
+  data?: unknown
+  timestamp: string
+}

--- a/apps/frontend/src/utils/randomUser.ts
+++ b/apps/frontend/src/utils/randomUser.ts
@@ -1,14 +1,11 @@
-interface StoredUser {
-  userId: string
-  name: string
-}
+import type { User } from '@/types/domain'
 
 const COLORS = ['빨간', '파란', '초록', '노란', '보라', '하얀', '검은', '주황', '분홍', '갈색']
 const FOODS = ['돈까스', '비빔밥', '라면', '떡볶이', '김치찌개', '불고기', '초밥', '만두', '갈비', '파스타']
 
 const pick = (list: string[]) => list[Math.floor(Math.random() * list.length)]
 
-export const createRandomUser = (): StoredUser => {
+export const createRandomUser = (): User => {
   const name = `${pick(COLORS)} ${pick(FOODS)}`
 
   return {

--- a/apps/frontend/src/utils/userStorage.ts
+++ b/apps/frontend/src/utils/userStorage.ts
@@ -1,22 +1,18 @@
+import type { User } from '@/types/domain'
 import { createRandomUser } from '@/utils/randomUser'
-
-export interface StoredUser {
-  userId: string
-  name: string
-}
 
 const USER_STORAGE_KEY_PREFIX = 'justhere.user'
 
 const getUserStorageKey = (roomSlug: string) => `${USER_STORAGE_KEY_PREFIX}.${roomSlug}`
 
-const loadStoredUser = (roomSlug: string): StoredUser | null => {
+const loadStoredUser = (roomSlug: string): User | null => {
   if (typeof window === 'undefined') return null
 
   const raw = localStorage.getItem(getUserStorageKey(roomSlug))
   if (!raw) return null
 
   try {
-    const parsed = JSON.parse(raw) as StoredUser
+    const parsed = JSON.parse(raw) as User
     if (!parsed?.userId || !parsed?.name) return null
     return parsed
   } catch {
@@ -24,11 +20,11 @@ const loadStoredUser = (roomSlug: string): StoredUser | null => {
   }
 }
 
-const saveStoredUser = (roomSlug: string, user: StoredUser) => {
+const saveStoredUser = (roomSlug: string, user: User) => {
   localStorage.setItem(getUserStorageKey(roomSlug), JSON.stringify(user))
 }
 
-export const getOrCreateStoredUser = (roomSlug: string): StoredUser => {
+export const getOrCreateStoredUser = (roomSlug: string): User => {
   const stored = loadStoredUser(roomSlug)
   if (stored) return stored
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

- Closes #189

<br>

## 📝 작업 내용

> #191 브랜치에서 작업을 계속 진행했으므로, e44fff8751a794ae24fe92209e6aa40b9cad3902 커밋부터 보시면 됩니다!

- 소켓 에러 페이로드 타입 추가
- 메인 페이지 에러 바운더리 추가
- room:error, category:error에서 에러 코드에 따라 에러 핸들러 추가
  - 존재하지 않는 방 입장 시 ErrorBoundary로 에러 페이지 렌더링
  - 세션 없이 액션 시 페이지 새로고침(새로운 소켓 발급)
  - 그 외 모든 에러는 토스트 컴포넌트로 메세지 렌더링

<br>

## 🖼️ 스크린샷 (선택)

| 에러 토스트 | 에러 페이지 |
|--------|--------|
| <img width="1552" height="981" alt="image" src="https://github.com/user-attachments/assets/220fed18-e48a-4d3b-b0e6-f245ca048ed6" /> | <img width="1552" height="981" alt="image" src="https://github.com/user-attachments/assets/c85987ca-4a95-4839-96ab-fcc0b3a43825" /> | 

<br>

## 테스트 및 검증 내용

> 로컬에서 직접 테스트

#### Error Boundary 재시도 로직 테스트

https://github.com/user-attachments/assets/d7cf5b90-c78d-4c88-9cc9-7a3282fdd867


<br>

## 🤔 주요 고민과 해결 과정

### room:error (Room/Participant 관련)

| 에러 타입 | 발생 상황 | 처리 |
| -- | -- | -- |
| NOT_FOUND | 존재하지 않는 방 입장 시도 | Error Boundary 전파 |
| NOT_IN_ROOM | 세션 없이 이름 변경/권한 위임 시도 | 페이지 새로고침 |
| NOT_OWNER | 방장이 아닌데 권한 위임 시도 | error 토스트 |
| TARGET_NOT_FOUND | 존재하지 않는 유저에게 권한 위임 | error 토스트 |
| INTERNAL_SERVER_ERROR | 서버 내부 오류 | error 토스트 |

### category:error

에러 타입 | 발생 상황 | 처리 |
| -- | -- | -- |
| NOT_IN_ROOM | 세션 없이 카테고리 생성/삭제 시도 | 페이지 새로고침 |
| CATEGORY_OVERFLOW_EXCEPTION | 10개 초과 카테고리 생성 시도 | error 토스트 |
| BAD_REQUEST | 마지막 카테고리 삭제 시도 | error 토스트 |
| NOT_FOUND | 존재하지 않는 카테고리 삭제 시도 | error 토스트 |


<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 알림 시스템 추가: 오류 및 중요 메시지를 화면에 표시
  * 개선된 오류 페이지: 방을 찾을 수 없을 때 명확한 안내 제공

* **버그 수정**
  * 연결 오류 및 방 접근 실패 시 더 나은 오류 처리
  * 오류 발생 시 안정적인 사용자 경험 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->