### PR TITLE
장소 카드 컴포넌트에 삭제/focus 기능 적용

### DIFF
--- a/apps/frontend/src/components/main/PlaceCardItem.tsx
+++ b/apps/frontend/src/components/main/PlaceCardItem.tsx
@@ -1,3 +1,4 @@
+import type Konva from 'konva'
 import { Group, Rect, Text, Image as KonvaImage } from 'react-konva'
 import { useImage } from 'react-konva-utils'
 import type { PlaceCard } from '@/types/canvas.types'
@@ -5,8 +6,11 @@ import type { PlaceCard } from '@/types/canvas.types'
 interface PlaceCardItemProps {
   card: PlaceCard
   draggable: boolean
+  isSelected?: boolean
   onDragEnd: (x: number, y: number) => void
   onRemove: () => void
+  onClick?: (e: Konva.KonvaEventObject<MouseEvent>) => void
+  onContextMenu?: (e: Konva.KonvaEventObject<MouseEvent>) => void
 }
 
 const CARD_WIDTH = 240
@@ -15,7 +19,7 @@ const IMAGE_HEIGHT = 90
 const PADDING = 12
 const PLACEHOLDER_SRC = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
 
-function PlaceCardItem({ card, draggable, onDragEnd, onRemove }: PlaceCardItemProps) {
+function PlaceCardItem({ card, draggable, isSelected, onDragEnd, onRemove, onClick, onContextMenu }: PlaceCardItemProps) {
   // konva를 쓰면 src로 이미지 받아서 렌더링하는게 안됨, 이미 로드된 이미지만 렌더링할 수 있다.
   // 원래 img 태그 쓰면 브라우저가 HTML 렌더링 엔진에서 자동으로 이미지 다운, 캐싱, 로딩 에러 처리 해줌, React는 문자열만 전달
   // konva는 canvas 기반이니까 브라우저의 이미지 로딩 시스템을 쓸 수 없음.
@@ -23,8 +27,22 @@ function PlaceCardItem({ card, draggable, onDragEnd, onRemove }: PlaceCardItemPr
   const [image] = useImage(card.image || PLACEHOLDER_SRC, 'anonymous')
 
   return (
-    <Group x={card.x} y={card.y} draggable={draggable} onDragEnd={e => onDragEnd(e.target.x(), e.target.y())}>
-      <Rect width={CARD_WIDTH} height={CARD_HEIGHT} fill="#FFFBE6" stroke="#E5E7EB" cornerRadius={10} />
+    <Group
+      x={card.x}
+      y={card.y}
+      draggable={draggable}
+      onDragEnd={e => onDragEnd(e.target.x(), e.target.y())}
+      onClick={onClick}
+      onContextMenu={onContextMenu}
+    >
+      <Rect
+        width={CARD_WIDTH}
+        height={CARD_HEIGHT}
+        fill="#FFFBE6"
+        stroke={isSelected ? '#3b82f6' : '#E5E7EB'}
+        strokeWidth={isSelected ? 3 : 1}
+        cornerRadius={10}
+      />
 
       {image && card.image ? (
         <KonvaImage image={image} x={PADDING} y={PADDING} width={CARD_WIDTH - PADDING * 2} height={IMAGE_HEIGHT} />

--- a/apps/frontend/src/types/canvas.types.ts
+++ b/apps/frontend/src/types/canvas.types.ts
@@ -1,6 +1,6 @@
-export type Tool = 'cursor' | 'pen' | 'rectangle'
+export type ToolType = 'hand' | 'pencil' | 'postIt'
 
-export type CanvasItemType = 'postit' | 'line'
+export type CanvasItemType = 'postit' | 'line' | 'placeCard'
 
 export interface SelectedItem {
   id: string


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

- Closes #203 


<br>

## 📝 작업 내용
> 작업한 내용을 작성해주세요.

1. 캔버스 아이템과 툴바 도구 타입을 외부로 분리 (canvas.type.ts)
2. 기존 로직에 장소 카드 삭제/focus 핸들러 등록 (WhiteboardCanvas.tsx)
3. 장소 카드 컴포넌트에 focus 기능 관련 props 추가 + focus 시 stroke 설정 추가 (PlaceCardItem.tsx)

<br>

## 🖼️ 스크린샷 (선택)

https://github.com/user-attachments/assets/60748e8e-84d5-417a-9d80-de58d0e39050

<br>

## 테스트 및 검증 내용
> 어떻게 테스트했고, 어떤 결과를 확인했는지 적어주세요.

기존에 구현되어있었던 객체 선택 핸들러, 객체 삭제 핸들러 등 로직들에 장소 카드 컴포넌트만 추가하는 간단한 작업이었습니다.

<br>


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

장소 카드 컴포넌트 select 시 stroke 두께를 3으로 지정했는데 많이 안 두껍나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 캔버스에서 장소 카드를 선택할 수 있습니다. 선택된 항목은 파란 테두리로 시각적으로 표시됩니다.
* 장소 카드에 대한 클릭 및 우클릭 상호작용을 지원합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->