### PR TITLE
카테고리 이동 시 유령 마우스 잔존 현상 해결

### DIFF
--- a/apps/frontend/src/hooks/useYjsSocket.ts
+++ b/apps/frontend/src/hooks/useYjsSocket.ts
@@ -185,7 +185,7 @@ export function useYjsSocket({ roomId, canvasId, userName }: UseYjsSocketOptions
     }
 
     const handleCanvasDetached = () => {
-      // TODO: 카테고리 나갔을 때 처리 로직
+      // TODO: 카테고리 나갔을 때 남겨진 사람들에게 필요한 로직
     }
 
     const handleYjsUpdate = (payload: YjsUpdateBroadcast) => {
@@ -256,6 +256,9 @@ export function useYjsSocket({ roomId, canvasId, userName }: UseYjsSocketOptions
       // 캔버스 나가기
       const detachPayload: CanvasDetachPayload = { canvasId }
       socket.emit('canvas:detach', detachPayload)
+
+      // UI에서 타 사람들의 커서 정리
+      setCursors(new Map())
 
       doc.off('update', updateHandler)
       socket.off('connect', handleConnect)


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

- Closes #232 


<br>

## 📝 작업 내용
> 작업한 내용을 작성해주세요.

- 캔버스 컴포넌트 언마운트 시 커서 UI를 초기화해주는 로직 추가 


<br>

## 🖼️ 스크린샷 (선택)

https://github.com/user-attachments/assets/0288dc42-3f78-4080-9557-502da8c97f30

다만, 다시 카테고리에 접속했을 때, 다른 참여자들의 커서 이동 이벤트가 발생할 때까지 커서 이벤트가 비어버리는 현상이 발생하지만, 활성화 중인 캔버스 내에서는 이미 커서가 활발하게 이동할 것이기 때문에 큰 문제가 되지 않으리라 판단.

<br>

## 🤔 주요 고민과 해결 과정

- [카테고리 이동 시 유령 마우스 잔존 현상 해결](https://www.notion.so/2f137262a1798077bcedd467c88ece6d?source=copy_link)


<br>

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<br>

## 🧩 참고 사항 (선택)

> 공유하고 싶은 링크나 게시글 등

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 캔버스 연결 해제 후 커서 UI가 제대로 초기화되지 않던 문제를 수정했습니다. 이제 컴포넌트가 언마운트될 때 커서 상태가 올바르게 리셋됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->