### PR TITLE
검색 실패 시 지도 중심 유지

### DIFF
--- a/apps/frontend/src/components/main/WhiteboardSection.tsx
+++ b/apps/frontend/src/components/main/WhiteboardSection.tsx
@@ -163,7 +163,7 @@ function WhiteboardSection({
               markers={searchResults}
               selectedMarkerId={selectedPlace?.id}
               onMarkerClick={onMarkerClick}
-              {...(searchResults[0] && { center: { lat: Number(searchResults[0].y), lng: Number(searchResults[0].x) } })}
+              center={getFirstResultCenter(searchResults)}
             />
           </div>
         )}
@@ -204,4 +204,9 @@ function resolveActiveCategoryId(categories: Category[], currentId: string) {
 
   const exists = categories.some(c => c.id === currentId)
   return exists ? currentId : categories[0].id
+}
+
+function getFirstResultCenter(results: KakaoPlace[]) {
+  if (!results[0]) return undefined
+  return { lat: Number(results[0].y), lng: Number(results[0].x) }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
> - Closes #240


<br>

## 📝 작업 내용
> 검색 실패 시 center prop의 전달을 막아 렌더링을 유지합니다.

<br>

## 🖼️ 스크린샷 


https://github.com/user-attachments/assets/3b9ce00d-8554-4922-9b8a-bf32c22ad5da



<br>

## 테스트 및 검증 내용
> 로컬 브라우저 테스트


<br>

## 🤔 주요 고민과 해결 과정

> - [트러블 슈팅](https://www.notion.so/2f337262a1798093b0faf87defa88244?source=copy_link)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 지도 중심 좌표 계산 로직을 정리했습니다.
* **버그 수정**
  * 검색 결과가 없을 때 지도가 의도치 않게 중심을 변경하지 않도록 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->