### PR TITLE
hotfix: WhiteboardSection 내부에서 center 관리하도록 변경

### DIFF
--- a/apps/frontend/src/components/main/WhiteboardSection.tsx
+++ b/apps/frontend/src/components/main/WhiteboardSection.tsx
@@ -43,10 +43,18 @@ function WhiteboardSection({
 
   const [activeCategoryId, setActiveCategoryId] = useState<string>('')
   const [viewMode, setViewMode] = useState<ToggleType>('canvas')
+  const [mapCenter, setMapCenter] = useState({ lat: 37.566826, lng: 126.9786567 })
 
   useEffect(() => {
     setActiveCategoryId(resolveActiveCategoryId(categories, activeCategoryId))
   }, [categories, activeCategoryId])
+
+  useEffect(() => {
+    const firstResult = searchResults[0]
+    if (firstResult) {
+      setMapCenter({ lat: Number(firstResult.y), lng: Number(firstResult.x) })
+    }
+  }, [searchResults])
 
   // 아이콘 맵퍼 (Type에 따라 아이콘 반환)
   const getIconByType = (type: string) => {
@@ -159,12 +167,7 @@ function WhiteboardSection({
           )
         ) : (
           <div className="w-full h-full bg-slate-100 flex items-center justify-center text-slate-400">
-            <KakaoMap
-              markers={searchResults}
-              selectedMarkerId={selectedPlace?.id}
-              onMarkerClick={onMarkerClick}
-              center={getFirstResultCenter(searchResults)}
-            />
+            <KakaoMap markers={searchResults} selectedMarkerId={selectedPlace?.id} onMarkerClick={onMarkerClick} center={mapCenter} />
           </div>
         )}
 
@@ -204,9 +207,4 @@ function resolveActiveCategoryId(categories: Category[], currentId: string) {
 
   const exists = categories.some(c => c.id === currentId)
   return exists ? currentId : categories[0].id
-}
-
-function getFirstResultCenter(results: KakaoPlace[]) {
-  if (!results[0]) return undefined
-  return { lat: Number(results[0].y), lng: Number(results[0].x) }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
> - Closes #이슈번호


<br>

## 📝 작업 내용
- WhiteboardSection에서 mapCenter 상태로 지도 중심 관리
- 검색 결과가 있을 때만 중심 좌표 업데이트, 없으면 이전 위치 유지


<br>

## 🖼️ 스크린샷

https://github.com/user-attachments/assets/23ce372a-e572-4755-8e49-8a63da8ea9ad




<br>

## 로컬 브라우저 테스트
> 어떻게 테스트했고, 어떤 결과를 확인했는지 적어주세요.

