### PR TITLE
포스트잇, 텍스트 배치 시 Tool 모드를 cursor로 변경

### DIFF
--- a/apps/frontend/src/pages/room/components/whiteboard/canvas/WhiteboardCanvas.tsx
+++ b/apps/frontend/src/pages/room/components/whiteboard/canvas/WhiteboardCanvas.tsx
@@ -168,6 +168,7 @@ export const WhiteboardCanvas = ({ roomId, canvasId, pendingPlaceCard, onPlaceCa
   } = useCanvasMouse({
     stageRef,
     effectiveTool,
+    setActiveTool,
     pendingPlaceCard,
     selectedItems,
     setSelectedItems,

--- a/apps/frontend/src/pages/room/hooks/canvas/useCanvasMouse.ts
+++ b/apps/frontend/src/pages/room/hooks/canvas/useCanvasMouse.ts
@@ -8,6 +8,7 @@ import { PLACE_CARD_HEIGHT, PLACE_CARD_WIDTH, POST_IT_HEIGHT, POST_IT_WIDTH } fr
 interface UseCanvasMouseProps {
   stageRef: React.RefObject<Konva.Stage | null>
   effectiveTool: ToolType
+  setActiveTool: (tool: ToolType) => void
   pendingPlaceCard: Omit<PlaceCard, 'x' | 'y'> | null
 
   // Selection
@@ -53,6 +54,7 @@ interface UseCanvasMouseProps {
 export const useCanvasMouse = ({
   stageRef,
   effectiveTool,
+  setActiveTool,
   pendingPlaceCard,
   selectedItems,
   setSelectedItems,
@@ -245,6 +247,8 @@ export const useCanvasMouse = ({
         }
         addPostIt(newPostIt)
         addSocketBreadcrumb('postit:add', { roomId, canvasId, id: newPostIt.id })
+        setActiveTool('cursor')
+        setCursorPos(null) // ghost 이미지 제거
       }
 
       if (effectiveTool === 'pencil') {
@@ -264,6 +268,8 @@ export const useCanvasMouse = ({
           authorName: userName,
         }
         addTextBox(newTextBox)
+        setActiveTool('cursor')
+        setCursorPos(null) // ghost 이미지 제거
       }
     },
     [
@@ -280,6 +286,7 @@ export const useCanvasMouse = ({
       addPostIt,
       startDrawing,
       addTextBox,
+      setActiveTool,
     ],
   )
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

- Closes #302


<br>

## 📝 작업 내용

1. WhiteboardCanvas.tsx에서 setActiveTool 함수를 useCanvasMouse로 내려주기
2. useCanvasMouse에서 addPostit, addTextBox에 setActiveTool 함수를 cursor로 실행


<br>

## 🖼️ 스크린샷 (선택)

https://github.com/user-attachments/assets/bf491f8a-3978-4c0c-b36f-a4596dcf7fa4


<br>

## 테스트 및 검증 내용

로컬 환경에서 직접 실행

<br>

## 🤔 주요 고민과 해결 과정

1. Toolbar를 관리하는 훅이 어떤 훅인지 파악 -> useCanvasMouse 확인
2. useCanvasMouse에서 포스트잇 추가, 텍스트 추가하는 함수 파악 -> 여기서 toolbar의 activeTool State의 setter 함수를 선언해줘야 함
3. 상위 layer의 depth가 1이므로 props로 내려줄 수 있다고 판단