### PR TITLE
도구 변경 시 커서 채팅이 종료되지 않도록 적용

### DIFF
--- a/apps/frontend/src/pages/room/components/whiteboard/canvas/WhiteboardCanvas.tsx
+++ b/apps/frontend/src/pages/room/components/whiteboard/canvas/WhiteboardCanvas.tsx
@@ -316,6 +316,7 @@ export const WhiteboardCanvas = ({ roomId, canvasId, pendingPlaceCard, onPlaceCa
 
       {isChatActive && chatInputPosition && (
         <CursorChatInput
+          key={activeTool}
           position={chatInputPosition}
           name={userName}
           isFading={isChatFading}


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

- Closes #344 

<br>

## 📝 작업 내용

### 문제 상황
tool = cursor 상태에서 / 를 입력하여 cursor chat을 수행하는 도중, tool을 다른 도구로 변경하게 되면, 기존에 cursor chat 입력, esc 등 키보드 이벤트 자체가 비활성화되는 문제 발생.

https://github.com/user-attachments/assets/8df88b37-0b18-4f39-b659-7a29c229d29f

### 해결

`CursorChatInput` 컴포넌트에 `key={activeTool}`을 추가 -> 도구가 변경될 때 컴포넌트가 다시 마운트되고 포커스를 획득하도록 수정


https://github.com/user-attachments/assets/f9991915-1035-4487-8300-44a32ebf3f87


<br>

## 테스트 및 검증 내용
> 어떻게 테스트했고, 어떤 결과를 확인했는지 적어주세요.

로컬에서 직접 테스트

<br>

## 🤔 주요 고민과 해결 과정

- AI의 도움을 받아서, WhiteboardCanvas 내 CursorChatInput에 key 속성을 추가하여, 도구를 변경해도 커서 채팅이 유지되며, 입력창에 포커스가 유지되어 계속 타이핑할 수 있게 적용함


<br>