### PR TITLE
ctrl + z / ctrl + shift + z 로 undo / redo 적용하기

### DIFF
--- a/apps/frontend/src/pages/room/components/whiteboard/canvas/WhiteboardCanvas.tsx
+++ b/apps/frontend/src/pages/room/components/whiteboard/canvas/WhiteboardCanvas.tsx
@@ -180,6 +180,8 @@ export const WhiteboardCanvas = ({ roomId, canvasId, pendingPlaceCard, onPlaceCa
     isDrawing,
     cancelDrawing,
     handleToolChange,
+    undo,
+    redo,
   })
   const effectiveTool = useMemo(() => (isSpacePressed ? 'hand' : activeTool), [isSpacePressed, activeTool])
 

--- a/apps/frontend/src/pages/room/hooks/canvas/useCanvasKeyboard.ts
+++ b/apps/frontend/src/pages/room/hooks/canvas/useCanvasKeyboard.ts
@@ -10,6 +10,8 @@ interface UseCanvasKeyboardOptions {
   isDrawing: boolean
   cancelDrawing: (reason: 'tool-change' | 'mouse-leave' | 'space-press') => void
   handleToolChange: (tool: ToolType) => void
+  undo: () => void
+  redo: () => void
 }
 
 /**
@@ -19,6 +21,8 @@ interface UseCanvasKeyboardOptions {
  * - Backspace: 선택된 아이템 삭제
  * - '/': 커서 채팅 활성화
  * - Space: Hand 모드 토글 (누르고 있는 동안)
+ * - Ctrl + Z: 실행 취소 (Undo)
+ * - Ctrl + Shift + Z: 다시 실행 (Redo)
  */
 export const useCanvasKeyboard = ({
   onPlaceCardCanceled,
@@ -29,6 +33,8 @@ export const useCanvasKeyboard = ({
   isDrawing,
   cancelDrawing,
   handleToolChange,
+  undo,
+  redo,
 }: UseCanvasKeyboardOptions) => {
   const [isSpacePressed, setIsSpacePressed] = useState(false)
 
@@ -49,6 +55,17 @@ export const useCanvasKeyboard = ({
 
       // 입력 필드에서는 나머지 단축키 무시
       if (isInputElement(e.target)) return
+
+      // Undo / Redo 단축키 적용
+      if ((e.ctrlKey || e.metaKey) && (e.key === 'z' || e.key === 'Z')) {
+        e.preventDefault()
+        if (e.shiftKey) {
+          redo()
+        } else {
+          undo()
+        }
+        return
+      }
 
       // Backspace: 선택 아이템 삭제
       if (e.key === 'Backspace' && hasSelectedItems) {
@@ -88,7 +105,18 @@ export const useCanvasKeyboard = ({
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('keyup', handleKeyUp)
     }
-  }, [onPlaceCardCanceled, hasSelectedItems, handleDeleteSelectedItems, isChatActive, activateCursorChat, isDrawing, cancelDrawing, handleToolChange])
+  }, [
+    onPlaceCardCanceled,
+    hasSelectedItems,
+    handleDeleteSelectedItems,
+    isChatActive,
+    activateCursorChat,
+    isDrawing,
+    cancelDrawing,
+    handleToolChange,
+    undo,
+    redo,
+  ])
 
   return { isSpacePressed }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- Closes #348 

<br>

## 📝 작업 내용

1. useCanvasKeyboard 훅에 키보드 이벤트 등록
2. WhiteboardCanvas 컴포넌트에 적용하기

<br>

## 🖼️ 스크린샷 (선택)


https://github.com/user-attachments/assets/5b9051ba-3854-44ec-9c10-4fd5a9ade4cd

<br>

## 테스트 및 검증 내용

직접 로컬에서 테스트 완료


<br>

## 🤔 주요 고민과 해결 과정


1. undo / redo 기능을 어디서 구현해야 하지?
    -> canvas 컴포넌트 내에서 호출되는 훅이므로, keyboard 훅에 undo / redo 기능을 구현.



<br>

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<br>

## 🧩 참고 사항 (선택)

> 공유하고 싶은 링크나 게시글 등