### PR TITLE
캔버스 요소 포커싱 시 커서 챗 비활성화되게 수정

### DIFF
--- a/apps/frontend/src/pages/room/components/whiteboard/canvas/WhiteboardCanvas.tsx
+++ b/apps/frontend/src/pages/room/components/whiteboard/canvas/WhiteboardCanvas.tsx
@@ -233,6 +233,7 @@ export const WhiteboardCanvas = ({ roomId, canvasId, pendingPlaceCard, onPlaceCa
     updateCursor,
     isChatActive,
     setChatInputPosition,
+    deactivateCursorChat,
     getIsDrawing,
     cancelDrawing,
     startDrawing,

--- a/apps/frontend/src/pages/room/hooks/canvas/useCanvasMouse.ts
+++ b/apps/frontend/src/pages/room/hooks/canvas/useCanvasMouse.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import React, { useState, useCallback } from 'react'
 import type Konva from 'konva'
 import { addSocketBreadcrumb } from '@/shared/utils'
 import type { ToolType, PostIt, PlaceCard, TextBox, SelectionBox, SelectedItem, CanvasItemType, BoundingBox, Line as LineType } from '@/shared/types'
@@ -28,6 +28,7 @@ interface UseCanvasMouseProps {
   updateCursor: (x: number, y: number) => void
   isChatActive: boolean
   setChatInputPosition: (pos: { x: number; y: number }) => void
+  deactivateCursorChat: () => void
 
   // Drawing
   getIsDrawing: () => boolean
@@ -74,6 +75,7 @@ export const useCanvasMouse = ({
   updateCursor,
   isChatActive,
   setChatInputPosition,
+  deactivateCursorChat,
   getIsDrawing,
   cancelDrawing,
   startDrawing,
@@ -101,6 +103,10 @@ export const useCanvasMouse = ({
 
   const handleObjectMouseDown = useCallback(
     (id: string, type: CanvasItemType, e: Konva.KonvaEventObject<MouseEvent>) => {
+      if (isChatActive) {
+        deactivateCursorChat()
+      }
+
       if (pendingPlaceCard) return
       if (effectiveTool !== 'cursor') return
 
@@ -119,7 +125,7 @@ export const useCanvasMouse = ({
         setSelectedItems(prev => [...prev, { id, type }])
       }
     },
-    [effectiveTool, pendingPlaceCard, selectedItems, setSelectedItems, moveToTop],
+    [effectiveTool, pendingPlaceCard, selectedItems, setSelectedItems, moveToTop, isChatActive, deactivateCursorChat],
   )
 
   const handleObjectClick = useCallback(
@@ -147,12 +153,16 @@ export const useCanvasMouse = ({
 
   const handleStageClick = useCallback(
     (e: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
+      if (isChatActive) {
+        deactivateCursorChat()
+      }
+
       if (e.target === e.target.getStage()) {
         setSelectedItems([])
         setContextMenu(null)
       }
     },
-    [setSelectedItems, setContextMenu],
+    [setSelectedItems, setContextMenu, isChatActive, deactivateCursorChat],
   )
 
   const handleMouseMove = useCallback(() => {
@@ -209,6 +219,10 @@ export const useCanvasMouse = ({
 
   const handleMouseDown = useCallback(
     (e: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
+      if (isChatActive) {
+        deactivateCursorChat()
+      }
+
       const isMouseEvent = e.evt.type.startsWith('mouse')
       if (isMouseEvent) {
         const mouseEvt = e.evt as MouseEvent
@@ -309,6 +323,8 @@ export const useCanvasMouse = ({
       currentDrawingLineRef,
       addTextBox,
       setActiveTool,
+      isChatActive,
+      deactivateCursorChat,
     ],
   )
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

- Closes #364 


<br>

## 📝 작업 내용

### 문제 상황

커서 챗 활성화 시 다른 도구를 변경할 때는 정상적으로 작동하게 됨. 그러나, 커서 챗 도중 다른 캔버스 요소를 클릭하여 포커싱이 옮겨지면, 커서 챗 이벤트가 활성화되지 않음.

https://github.com/user-attachments/assets/52402721-8f90-4c9c-bfc7-1f711774de3a


### 해결 방안

- 기존의 피그잼처럼, 커서 챗 활성화 도중, 다른 클릭 이벤트로 인해 포커스가 해제될 경우(도구를 변경, 캔버스 요소 클릭 등), 커서 챗을 없애는 방식으로 변경

https://github.com/user-attachments/assets/f046d4f7-fa16-4cc3-93e3-a5308ba56cdb

- 주요 작업

1. useCanvasMouse에서 캔버스 요소에 클릭 이벤트 발생 시 deactiveCursorChat 실행
2. useCanvasMouse에 파라미터에 deactiveCursorChat 추가

<br>

## 🖼️ 결과 스크린샷


https://github.com/user-attachments/assets/3162b2e2-db8b-461e-a7e9-fbd686119a28


<br>

## 테스트 및 검증 내용

로컬에서 테스트 

<br>


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

기존에 커서 챗 도중 툴을 변경하게 될 때, 커서 챗이 유지가 되게 변경해둔 상황이었잖아요?

그래서인지 동작이 일관되게, 도구도 마찬가지로 변경 시 커서 챗을 deactive하게 설정해야 할 지 고민입니다.

<br>
