### PR TITLE
카테고리 변경하면 장소 리스트 캐싱이 안되는 버그 수정

### DIFF
--- a/apps/frontend/src/shared/hooks/queries/useGoogleQueries.ts
+++ b/apps/frontend/src/shared/hooks/queries/useGoogleQueries.ts
@@ -13,6 +13,8 @@ export const useGoogleSearch = (params: SearchTextParams) => {
     queryKey: googleKeys.search(params),
     queryFn: () => searchText(params),
     enabled: !!params.textQuery,
+    staleTime: Infinity,
+    gcTime: 1000 * 60 * 60,
   })
 }
 
@@ -32,8 +34,8 @@ export const useInfiniteGoogleSearch = (params: Omit<SearchTextParams, 'pageToke
     initialPageParam: undefined as string | undefined,
     getNextPageParam: lastPage => lastPage.nextPageToken,
     enabled: !!textQuery,
-    staleTime: 0,
-    gcTime: 0,
+    staleTime: Infinity,
+    gcTime: 1000 * 60 * 60,
     select: data => ({
       pages: data.pages.flatMap(page => page.places),
       pageParams: data.pageParams,
@@ -46,6 +48,8 @@ export const useGooglePlaceDetails = (placeId: string) => {
     queryKey: googleKeys.placeDetails(placeId),
     queryFn: () => getPlaceDetails(placeId),
     enabled: !!placeId,
+    staleTime: Infinity,
+    gcTime: 1000 * 60 * 60,
   })
 }
 
@@ -58,7 +62,7 @@ export const useGooglePhotos = (photoNames: (string | undefined | null)[], maxWi
         queryKey: googleKeys.photo(name, maxWidthPx, maxHeightPx),
         queryFn: () => getPhotoUrl(name, maxWidthPx, maxHeightPx),
         staleTime: Infinity,
-        gcTime: 1000 * 60 * 60, // Cache for 1 hour
+        gcTime: 1000 * 60 * 60,
       })),
   })
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

- Closes #369


<br>

## 📝 작업 내용

- 구글 검색 쿼리 `staleTime: Infinity`, `gcTime: 1시간`으로 수정
    - 데이터 stale 상태 안되게 처리
    - 의도적으로 refetch 호출 시 캐싱되어 있던 데이터 사용
    - 데이터 캐시 유효 시간은 1시간

<br>

## 🖼️ 스크린샷


https://github.com/user-attachments/assets/a55d45ce-a6a8-41c3-beea-e7ca3964e7ee



<br>

## 테스트 및 검증 내용

> 로컬에서 실행


<br>
