### PR TITLE
Transform를 잡고 캔버스를 옮기면 Transform이 이상해지는 문제 해결

### DIFF
--- a/apps/frontend/src/pages/room/components/whiteboard/canvas/WhiteboardCanvas.tsx
+++ b/apps/frontend/src/pages/room/components/whiteboard/canvas/WhiteboardCanvas.tsx
@@ -270,6 +270,12 @@ export const WhiteboardCanvas = ({ roomId, canvasId, pendingPlaceCard, onPlaceCa
     return () => cancelAnimationFrame(id)
   }, [selectedItems])
 
+  useEffect(() => {
+    return () => {
+      setSelectedItems([])
+    }
+  }, [canvasId])
+
   const linesMap = useMemo(() => new Map(lines.map(line => [line.id, line])), [lines])
   const postItsMap = useMemo(() => new Map(postIts.map(postIt => [postIt.id, postIt])), [postIts])
   const placeCardsMap = useMemo(() => new Map(placeCards.map(card => [card.id, card])), [placeCards])


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- Closes #383


<br>

## 📝 작업 내용
- Transform이 있는 상태에서 카테고리 변경 시 Transform이 없어지도록 수정


<br>

## 🖼️ 스크린샷 (선택)

https://github.com/user-attachments/assets/97843730-0c6b-403a-9f11-575d9d03221b




<br>

## 테스트 및 검증 내용
- 로컬에서 직접 테스트함


<br>

## 🤔 주요 고민과 해결 과정
- canvasId가 변할때 선택된 아이템 목록을 빈배열로 넘기기만 하면 돼서 너무 간단했다..
