### PR TITLE
툴팁 추가 및 수정

### DIFF
--- a/apps/frontend/src/pages/room/components/whiteboard/canvas/toolbar/keyboard-shortcuts/KeyboardShortcutsDropdown.tsx
+++ b/apps/frontend/src/pages/room/components/whiteboard/canvas/toolbar/keyboard-shortcuts/KeyboardShortcutsDropdown.tsx
@@ -2,12 +2,17 @@ import { useState } from 'react'
 import { HelpCircleIcon } from '@/shared/assets'
 import { Button, Divider, Dropdown, Tooltip } from '@/shared/components'
 
+const isMac = /Mac|iPhone|iPod|iPad/.test(navigator.userAgent)
+const modifier = isMac ? '⌘' : 'Ctrl'
+
 const SHORTCUTS = [
   { key: 'Space bar', description: '누르는 동안 이동 도구 전환' },
   { key: 'Backspace', description: '선택된 캔버스 요소 삭제' },
   { key: 'ESC', description: '선택 도구 전환' },
+  { key: `${modifier} + Z`, description: '실행 취소 (Undo)' },
+  { key: `${modifier} + Shift + Z`, description: '재실행 (Redo)' },
   { key: '/', description: '마우스 채팅(최대 50자)' },
-  { key: 'Ctrl + 마우스 휠', description: '줌 인/아웃' },
+  { key: `${modifier} + 마우스 휠`, description: '줌 인/아웃' },
   { key: '마우스 우클릭', description: '추가 옵션' },
 ]
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- Closes #424


<br>

## 📝 작업 내용
- 키보드 단축키 -> 단축키로 네이밍 수정
- undo/redo 툴팁 추가
- 맥/윈도우 여부에 따라 Ctrl/⌘ 로 표시되도록 수정


<br>

## 🖼️ 스크린샷 (선택)
<img width="369" height="349" alt="image" src="https://github.com/user-attachments/assets/c19fc197-2766-4d0a-ba06-3012dc21e1fe" />



<br>

## 테스트 및 검증 내용
- 단순 툴팁만 변경해서 테스트는 진행하지 않음


<br>

## 🤔 주요 고민과 해결 과정
- OS 판단 시에 `navigator.platform`을 사용하면 편하지만 deprecated됨
  - 보안 및 호환성 문제로 폐기
- `navigator.userAgent` + 정규식 조합으로 Mac 유저인지 판단하도록 구현함
