### PR TITLE
FE 빌드 최적화

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: cd.yml
 on:
   push:
     branches:
-      - main
+      - refactor/432-build-optimization
 
 jobs:
   build-and-push:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: cd.yml
 on:
   push:
     branches:
-      - refactor/432-build-optimization
+      - main
 
 jobs:
   build-and-push:

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -7,7 +7,7 @@
     <title>딱! 여기</title>
 
     <!-- Google Maps API 사전 연결 (room 페이지 진입 시 연결 지연 감소) -->
-    <link rel="preconnect" href="https://maps.googleapis.com" />
+    <link rel="preconnect" href="https://maps.googleapis.com" crossorigin />
     <link rel="preconnect" href="https://maps.gstatic.com" crossorigin />
 
     <!-- Open Graph -->

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -6,6 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>딱! 여기</title>
 
+    <!-- Google Maps API 사전 연결 (room 페이지 진입 시 연결 지연 감소) -->
+    <link rel="preconnect" href="https://maps.googleapis.com" />
+    <link rel="preconnect" href="https://maps.gstatic.com" crossorigin />
+
     <!-- Open Graph -->
     <meta property="og:title" content="딱! 여기 - 실시간 모임 장소 선정" />
     <meta property="og:description" content="우리 어디서 만나? 딱! 여기에서 실시간으로 재밌게 정하자!" />

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "build:analyze": "tsc -b && ANALYZE=true vite build",
+    "build:analyze": "tsc -b && cross-env ANALYZE=true vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run --passWithNoTests",
@@ -40,6 +40,7 @@
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react-swc": "^4.2.2",
+    "cross-env": "^10.1.0",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:analyze": "tsc -b && ANALYZE=true vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run --passWithNoTests",
@@ -43,6 +44,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "rollup-plugin-visualizer": "^7.0.0",
     "svgo": "^4.0.0",
     "tailwindcss": "^4.1.17",
     "typescript": "~5.9.3",

--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense } from 'react'
 import { Outlet, Route, Routes } from 'react-router-dom'
-import { RoomErrorBoundary } from './error-boundary'
+import { AppErrorBoundary, RoomErrorBoundary } from './error-boundary'
 import { RoomSocketProvider } from '@/pages/room/contexts'
 
 const LandingPage = lazy(() => import('@/pages/landing/page'))
@@ -8,28 +8,36 @@ const OnboardingPage = lazy(() => import('@/pages/onboarding/page'))
 const RoomPage = lazy(() => import('@/pages/room/page'))
 const ResultPage = lazy(() => import('@/pages/result/page').then(m => ({ default: m.ResultPage })))
 
+const PageFallback = () => (
+  <div className="min-h-screen flex items-center justify-center">
+    <div className="size-8 rounded-full border-4 border-primary border-t-transparent animate-spin" />
+  </div>
+)
+
 export function App() {
   return (
-    <Suspense>
-      <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/onboarding" element={<OnboardingPage />} />
+    <AppErrorBoundary>
+      <Suspense fallback={<PageFallback />}>
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/onboarding" element={<OnboardingPage />} />
 
-        {/* 중첩 라우트: RoomLayout이 소켓 연결 관리 */}
-        <Route
-          element={
-            <RoomErrorBoundary>
-              <RoomSocketProvider>
-                <Outlet />
-              </RoomSocketProvider>
-            </RoomErrorBoundary>
-          }
-        >
-          <Route path="/room/:slug" element={<RoomPage />} />
-          <Route path="/result/:slug" element={<ResultPage />} />
-        </Route>
-      </Routes>
-    </Suspense>
+          {/* 중첩 라우트: RoomLayout이 소켓 연결 관리 */}
+          <Route
+            element={
+              <RoomErrorBoundary>
+                <RoomSocketProvider>
+                  <Outlet />
+                </RoomSocketProvider>
+              </RoomErrorBoundary>
+            }
+          >
+            <Route path="/room/:slug" element={<RoomPage />} />
+            <Route path="/result/:slug" element={<ResultPage />} />
+          </Route>
+        </Routes>
+      </Suspense>
+    </AppErrorBoundary>
   )
 }
 

--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -1,28 +1,35 @@
+import { lazy, Suspense } from 'react'
 import { Outlet, Route, Routes } from 'react-router-dom'
-import { LandingPage, OnboardingPage, ResultPage, RoomPage } from '@/pages'
 import { RoomErrorBoundary } from './error-boundary'
 import { RoomSocketProvider } from '@/pages/room/contexts'
 
+const LandingPage = lazy(() => import('@/pages/landing/page'))
+const OnboardingPage = lazy(() => import('@/pages/onboarding/page'))
+const RoomPage = lazy(() => import('@/pages/room/page'))
+const ResultPage = lazy(() => import('@/pages/result/page').then(m => ({ default: m.ResultPage })))
+
 export function App() {
   return (
-    <Routes>
-      <Route path="/" element={<LandingPage />} />
-      <Route path="/onboarding" element={<OnboardingPage />} />
+    <Suspense>
+      <Routes>
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/onboarding" element={<OnboardingPage />} />
 
-      {/* 중첩 라우트: RoomLayout이 소켓 연결 관리 */}
-      <Route
-        element={
-          <RoomErrorBoundary>
-            <RoomSocketProvider>
-              <Outlet />
-            </RoomSocketProvider>
-          </RoomErrorBoundary>
-        }
-      >
-        <Route path="/room/:slug" element={<RoomPage />} />
-        <Route path="/result/:slug" element={<ResultPage />} />
-      </Route>
-    </Routes>
+        {/* 중첩 라우트: RoomLayout이 소켓 연결 관리 */}
+        <Route
+          element={
+            <RoomErrorBoundary>
+              <RoomSocketProvider>
+                <Outlet />
+              </RoomSocketProvider>
+            </RoomErrorBoundary>
+          }
+        >
+          <Route path="/room/:slug" element={<RoomPage />} />
+          <Route path="/result/:slug" element={<ResultPage />} />
+        </Route>
+      </Routes>
+    </Suspense>
   )
 }
 

--- a/apps/frontend/src/app/error-boundary/AppErrorBoundary.tsx
+++ b/apps/frontend/src/app/error-boundary/AppErrorBoundary.tsx
@@ -1,0 +1,34 @@
+import { Component, type ReactNode } from 'react'
+
+type Props = { children: ReactNode }
+type State = { hasError: boolean }
+
+export class AppErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex flex-col items-center justify-center gap-4 bg-gray-50">
+          <p className="text-lg font-semibold text-gray-700">앱을 불러오는 중 오류가 발생했습니다.</p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="px-6 py-2 bg-primary text-white rounded-lg font-semibold hover:bg-primary/90 transition-colors"
+          >
+            새로고침
+          </button>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/apps/frontend/src/app/error-boundary/index.ts
+++ b/apps/frontend/src/app/error-boundary/index.ts
@@ -1,1 +1,2 @@
+export { AppErrorBoundary } from './AppErrorBoundary'
 export { RoomErrorBoundary } from './RoomErrorBoundary'

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -38,7 +38,7 @@ export default defineConfig(() => {
   return {
     plugins,
     build: {
-      sourcemap: 'hidden',
+      sourcemap: 'hidden' as const,
       rollupOptions: {
         output: {
           manualChunks: {

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react-swc'
 import tailwindcss from '@tailwindcss/vite'
 import svgr from 'vite-plugin-svgr'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
+import { visualizer } from 'rollup-plugin-visualizer'
 
 // https://vite.dev/config/
 export default defineConfig(() => {
@@ -23,10 +24,31 @@ export default defineConfig(() => {
     }),
   )
 
+  if (process.env.ANALYZE) {
+    plugins.push(
+      visualizer({
+        open: true,
+        filename: 'dist/stats.html',
+        gzipSize: true,
+        brotliSize: true,
+      }),
+    )
+  }
+
   return {
     plugins,
     build: {
       sourcemap: true,
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            'vendor-canvas': ['konva', 'react-konva', 'react-konva-utils'],
+            'vendor-collab': ['yjs', 'socket.io-client'],
+            'vendor-map': ['@vis.gl/react-google-maps'],
+            'vendor-sentry': ['@sentry/react'],
+          },
+        },
+      },
     },
     resolve: {
       alias: {

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -45,7 +45,6 @@ export default defineConfig(() => {
             'vendor-canvas': ['konva', 'react-konva', 'react-konva-utils'],
             'vendor-collab': ['yjs', 'socket.io-client'],
             'vendor-map': ['@vis.gl/react-google-maps'],
-            'vendor-sentry': ['@sentry/react'],
           },
         },
       },

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -38,7 +38,7 @@ export default defineConfig(() => {
   return {
     plugins,
     build: {
-      sourcemap: true,
+      sourcemap: 'hidden',
       rollupOptions: {
         output: {
           manualChunks: {

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -43,10 +43,44 @@ server {
 
     ssl_protocols TLSv1.2 TLSv1.3;
 
+    # gzip 압축
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_min_length 1024;
+    gzip_types
+        text/plain
+        text/css
+        text/javascript
+        application/javascript
+        application/json
+        application/xml
+        image/svg+xml
+        font/woff2;
+
+    # Vite 빌드 정적 자산 (파일명에 content hash 포함) - 장기 캐시
+    location ~* \.(?:js|css|woff2|woff|ttf|otf|eot)$ {
+        root /usr/share/nginx/html;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        access_log off;
+    }
+
+    location ~* \.(?:png|jpg|jpeg|gif|ico|webp|avif|svg)$ {
+        root /usr/share/nginx/html;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        access_log off;
+    }
+
     # React 정적 파일 서빙
     location / {
         root   /usr/share/nginx/html;
         index  index.html;
+
+        # index.html은 캐시하지 않음 (SPA 진입점)
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
 
         # SPA 필수 설정
         try_files $uri $uri/ /index.html;

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -56,8 +56,7 @@ server {
         application/javascript
         application/json
         application/xml
-        image/svg+xml
-        font/woff2;
+        image/svg+xml;
 
     # Vite 빌드 정적 자산 (파일명에 content hash 포함) - 장기 캐시
     location ~* \.(?:js|css|woff2|woff|ttf|otf|eot)$ {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
         version: 4.2.2(vite@7.2.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       eslint:
         specifier: ^9.39.1
         version: 9.39.1(jiti@2.6.1)
@@ -534,6 +537,9 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -2890,6 +2896,11 @@ packages:
   cron@4.3.5:
     resolution: {integrity: sha512-hKPP7fq1+OfyCqoePkKfVq7tNAdFwiQORr4lZUHwrf0tebC65fYEeWgOrXOL6prn1/fegGOdTfrM6e34PJfksg==}
     engines: {node: '>=18.x'}
+
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -5792,6 +5803,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
@@ -8307,6 +8320,11 @@ snapshots:
     dependencies:
       '@types/luxon': 3.7.1
       luxon: 3.7.2
+
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,9 @@ importers:
       globals:
         specifier: ^16.5.0
         version: 16.5.0
+      rollup-plugin-visualizer:
+        specifier: ^7.0.0
+        version: 7.0.0(rollup@4.53.3)
       svgo:
         specifier: ^4.0.0
         version: 4.0.0
@@ -2650,6 +2653,10 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
@@ -2765,6 +2772,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -2934,8 +2945,20 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
@@ -3553,6 +3576,11 @@ packages:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -3572,6 +3600,15 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
@@ -3594,6 +3631,10 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -4245,6 +4286,10 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -4420,6 +4465,10 @@ packages:
   postgres@3.4.7:
     resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
     engines: {node: '>=12'}
+
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -4615,6 +4664,19 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rollup-plugin-visualizer@7.0.0:
+    resolution: {integrity: sha512-loo4kmhTg7GMO0hqaUv/azvLPUT2B4jXU3gNMG35gm1mWKpOzhV6rspb/Mqmsfg7oOTdkzdmOckCIwGB5Ca1CA==}
+    engines: {node: '>=22'}
+    hasBin: true
+    peerDependencies:
+      rolldown: 1.x || ^1.0.0-beta || ^1.0.0-rc
+      rollup: 2.x || 3.x || 4.x
+    peerDependenciesMeta:
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+
   rollup@4.53.3:
     resolution: {integrity: sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -4623,6 +4685,10 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
 
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
@@ -5353,6 +5419,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+    engines: {node: '>=20'}
+
   xmlhttprequest-ssl@2.1.2:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
     engines: {node: '>=0.4.0'}
@@ -5377,9 +5447,17 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yjs@13.6.29:
     resolution: {integrity: sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==}
@@ -8010,6 +8088,10 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
@@ -8133,6 +8215,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
+      wrap-ansi: 9.0.2
 
   clone@1.0.4: {}
 
@@ -8264,9 +8352,18 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
+
+  define-lazy-prop@3.0.0: {}
 
   defu@6.1.4: {}
 
@@ -8951,6 +9048,8 @@ snapshots:
     dependencies:
       binary-extensions: 2.3.0
 
+  is-docker@3.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -8965,6 +9064,12 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-in-ssh@1.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
   is-interactive@1.0.0: {}
 
   is-number@7.0.0: {}
@@ -8976,6 +9081,10 @@ snapshots:
   is-stream@2.0.1: {}
 
   is-unicode-supported@0.1.0: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
 
@@ -9778,6 +9887,15 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  open@11.0.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -9936,6 +10054,8 @@ snapshots:
       xtend: 4.0.2
 
   postgres@3.4.7: {}
+
+  powershell-utils@0.1.0: {}
 
   prelude-ls@1.2.1: {}
 
@@ -10125,6 +10245,15 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rollup-plugin-visualizer@7.0.0(rollup@4.53.3):
+    dependencies:
+      open: 11.0.0
+      picomatch: 4.0.3
+      source-map: 0.7.6
+      yargs: 18.0.0
+    optionalDependencies:
+      rollup: 4.53.3
+
   rollup@4.53.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -10162,6 +10291,8 @@ snapshots:
       path-to-regexp: 8.3.0
     transitivePeerDependencies:
       - supports-color
+
+  run-applescript@7.1.0: {}
 
   rxjs@7.8.1:
     dependencies:
@@ -10920,6 +11051,11 @@ snapshots:
 
   ws@8.18.3: {}
 
+  wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
+
   xmlhttprequest-ssl@2.1.2: {}
 
   xtend@4.0.2: {}
@@ -10932,6 +11068,8 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
+  yargs-parser@22.0.0: {}
+
   yargs@17.7.2:
     dependencies:
       cliui: 8.0.1
@@ -10941,6 +11079,15 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   yjs@13.6.29:
     dependencies:


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
> - Closes #432 


<br>

## 📝 작업 내용

- 프론트엔드 번들 크기 및 로딩 성능 최적화 작업입니다.

### 번들 최적화
- `React.lazy` + `Suspense`로 라우트 단위 코드 스플리팅 적용
  - landing, onboarding, room, result 페이지 모두 동적 import로 전환
  - konva, yjs, socket.io-client 등 room 전용 라이브러리가 초기 로드에서 제외됨
- vite.config.ts에 `manualChunks` 설정 추가
  - `vendor-canvas`: konva, react-konva, react-konva-utils
  - `vendor-collab`: yjs, socket.io-client
  - `vendor-map`: @vis.gl/react-google-maps
  - `vendor-sentry`: @sentry/react
- `rollup-plugin-visualizer` 추가 (`pnpm build:analyze`로 번들 시각화 가능)

### nginx 최적화
- gzip 압축 활성화 (JS, CSS, JSON, SVG, 폰트)
- 정적 자산(JS/CSS/이미지/폰트) `Cache-Control: public, immutable` 1년 장기 캐시 설정
- index.html `Cache-Control: no-cache` 설정 (SPA 진입점 항상 최신 버전 보장)

### 기타
- `sourcemap: true` → `sourcemap: 'hidden'` 변경 (브라우저에서 소스코드 노출 방지, Sentry 에러 추적은 유지)
- index.html에 Google Maps API preconnect 힌트 추가 (`maps.googleapis.com`, `maps.gstatic.com`)

## 성능 개선 결과

### Lighthouse (온보딩·메인 페이지 기준)

| 지표 | 전 | 후 |
|---|---|---|
| FCP | 1.5초 | **0.6초** |
| LCP | 2.2초 | **1.2초** |
| Speed Index | 1.5초 | **약 0.9초** |

### 번들 크기

| 구분 | 전 | 후 |
|---|---|---|
| 초기 로드 JS (gzip) | 475 kB | **196 kB** (-59%) |
| 초기 로드 JS (raw) | 1,297 kB (단일 파일) | **383 kB** |

> landing/onboarding 방문자는 room 전용 번들 합계 ~800kB를 전혀 다운로드하지 않음


<br>

## 🖼️ 스크린샷 (선택)

### 개선전

<img width="2934" height="1738" alt="image" src="https://github.com/user-attachments/assets/4a899942-252f-4f52-a65d-74e67c21e150" />

<img width="2934" height="1738" alt="image" src="https://github.com/user-attachments/assets/e5439de1-f55e-497e-b9b0-d86c06da29f9" />


### 개선후

<img width="2944" height="1762" alt="image" src="https://github.com/user-attachments/assets/094a073f-1b14-43d2-9314-2110dd121f2e" />

<img width="2936" height="1758" alt="image" src="https://github.com/user-attachments/assets/90502604-4650-4957-9950-702083aa5450" />

<br>

## 테스트 및 검증 내용
> 어떻게 테스트했고, 어떤 결과를 확인했는지 적어주세요.

- 빌드 최적화 결과를 보기위해 위 최적화를 진행하기 전과 후의 Lighthouse 지표를 확인했습니다.
- rollup-plugin-visualizer 라이브러리로 번들 크기를 시각화해 확인했습니다.



## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<br>

## 🧩 참고 사항 (선택)

- 관련 문서 링크
https://www.notion.so/FE-31137262a17980eebdb2d3c6e572b9c7?v=2c337262a17980b0bcb0000c27aff55c&source=copy_link