### PR TITLE
Canvas 모듈 리팩터링

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -15,7 +15,7 @@ import { SocketModule } from '@/modules/socket/socket.module'
 import { UserModule } from '@/modules/user/user.module'
 import { CategoryModule } from '@/modules/category/category.module'
 import { RoomModule } from '@/modules/room/room.module'
-import { YjsModule } from '@/modules/canvas/yjs.module'
+import { CanvasModule } from '@/modules/canvas/canvas.module'
 import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core'
 
 @Module({
@@ -28,7 +28,7 @@ import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core'
     UserModule,
     CategoryModule,
     RoomModule,
-    YjsModule,
+    CanvasModule,
     VoteModule,
     SwaggerConfigModule,
     PrometheusModule.register({

--- a/apps/backend/src/modules/canvas/canvas.gateway.spec.ts
+++ b/apps/backend/src/modules/canvas/canvas.gateway.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { CanvasGateway } from './canvas.gateway'
-import { YjsService } from './yjs.service'
+import { CanvasService } from './canvas.service'
 import { CanvasBroadcaster } from '@/modules/socket/canvas.broadcaster'
 import { Socket, Server } from 'socket.io'
 import { CanvasAttachPayload, CanvasDetachPayload, YjsUpdatePayload, YjsAwarenessPayload } from './dto/yjs.dto'
@@ -36,7 +36,7 @@ describe('CanvasGateway', () => {
     jest.clearAllMocks()
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CanvasGateway, { provide: YjsService, useValue: mockYjsService }, { provide: CanvasBroadcaster, useValue: mockBroadcaster }],
+      providers: [CanvasGateway, { provide: CanvasService, useValue: mockYjsService }, { provide: CanvasBroadcaster, useValue: mockBroadcaster }],
     }).compile()
 
     gateway = module.get(CanvasGateway)

--- a/apps/backend/src/modules/canvas/canvas.gateway.ts
+++ b/apps/backend/src/modules/canvas/canvas.gateway.ts
@@ -10,7 +10,7 @@ import {
   ConnectedSocket,
 } from '@nestjs/websockets'
 import { Server, Socket } from 'socket.io'
-import { YjsService } from './yjs.service'
+import { CanvasService } from './canvas.service'
 import { CanvasBroadcaster } from '@/modules/socket/canvas.broadcaster'
 import { CanvasAttachPayload, CanvasDetachPayload, YjsUpdatePayload, YjsAwarenessPayload } from './dto/yjs.dto'
 
@@ -24,7 +24,7 @@ export class CanvasGateway implements OnGatewayInit, OnGatewayDisconnect {
   server: Server
 
   constructor(
-    private readonly yjsService: YjsService,
+    private readonly canvasService: CanvasService,
     private readonly broadcaster: CanvasBroadcaster,
   ) {}
 
@@ -33,7 +33,7 @@ export class CanvasGateway implements OnGatewayInit, OnGatewayDisconnect {
   }
 
   handleDisconnect(client: Socket) {
-    const canvasIds = this.yjsService.disconnectClient(client.id)
+    const canvasIds = this.canvasService.disconnectClient(client.id)
 
     // 참여 중이던 캔버스들에 커서 삭제 브로드캐스트
     for (const canvasId of canvasIds) {
@@ -52,7 +52,7 @@ export class CanvasGateway implements OnGatewayInit, OnGatewayDisconnect {
     const { roomId, canvasId } = payload
 
     // 서비스 초기화
-    const response = await this.yjsService.initializeConnection(roomId, canvasId, client.id)
+    const response = await this.canvasService.initializeConnection(roomId, canvasId, client.id)
 
     // Socket.io room에 참여
     await client.join(`canvas:${canvasId}`)
@@ -74,7 +74,7 @@ export class CanvasGateway implements OnGatewayInit, OnGatewayDisconnect {
     })
 
     await client.leave(`canvas:${canvasId}`)
-    this.yjsService.disconnectClient(client.id)
+    this.canvasService.disconnectClient(client.id)
 
     client.emit('canvas:detached', {})
   }
@@ -90,7 +90,7 @@ export class CanvasGateway implements OnGatewayInit, OnGatewayDisconnect {
     const updateArray = new Uint8Array(update)
 
     // Yjs 문서에 업데이트 적용 & 버퍼링
-    this.yjsService.processUpdate(canvasId, updateArray)
+    this.canvasService.processUpdate(canvasId, updateArray)
 
     // 다른 클라이언트들에게 업데이트 브로드캐스트
     this.broadcaster.emitToCanvas(canvasId, 'y:update', payload, { exceptSocketId: client.id })

--- a/apps/backend/src/modules/canvas/canvas.module.ts
+++ b/apps/backend/src/modules/canvas/canvas.module.ts
@@ -9,4 +9,4 @@ import { CanvasRepository } from './canvas.repository'
   providers: [YjsService, CanvasGateway, CanvasRepository],
   exports: [YjsService],
 })
-export class YjsModule {}
+export class CanvasModule {}

--- a/apps/backend/src/modules/canvas/canvas.module.ts
+++ b/apps/backend/src/modules/canvas/canvas.module.ts
@@ -1,12 +1,12 @@
 import { Module } from '@nestjs/common'
-import { YjsService } from './yjs.service'
+import { CanvasService } from './canvas.service'
 import { CanvasGateway } from './canvas.gateway'
 import { SocketModule } from '@/modules/socket/socket.module'
 import { CanvasRepository } from './canvas.repository'
 
 @Module({
   imports: [SocketModule],
-  providers: [YjsService, CanvasGateway, CanvasRepository],
-  exports: [YjsService],
+  providers: [CanvasService, CanvasGateway, CanvasRepository],
+  exports: [CanvasService],
 })
 export class CanvasModule {}

--- a/apps/backend/src/modules/canvas/canvas.repository.spec.ts
+++ b/apps/backend/src/modules/canvas/canvas.repository.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { CanvasRepository } from './canvas.repository'
+import { PrismaService } from '@/lib/prisma/prisma.service'
+import * as Y from 'yjs'
+
+describe('CanvasRepository', () => {
+  let repository: CanvasRepository
+
+  // Manual Mock 객체 정의
+  let mockPrisma: {
+    categoryUpdateLog: {
+      findMany: jest.Mock
+      create: jest.Mock
+    }
+  }
+
+  beforeEach(async () => {
+    // Mock 구현
+    mockPrisma = {
+      categoryUpdateLog: {
+        findMany: jest.fn(),
+        create: jest.fn(),
+      },
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CanvasRepository,
+        {
+          provide: PrismaService,
+          useValue: mockPrisma, // Manual Mock 주입
+        },
+      ],
+    }).compile()
+
+    repository = module.get<CanvasRepository>(CanvasRepository)
+  })
+
+  describe('getMergedUpdate', () => {
+    it('로그가 없으면 빈 Uint8Array를 반환해야 한다', async () => {
+      mockPrisma.categoryUpdateLog.findMany.mockResolvedValue([])
+
+      const result = await repository.getMergedUpdate('cat-1')
+
+      expect(result).toBeInstanceOf(Uint8Array)
+      expect(result.byteLength).toBe(0)
+      expect(mockPrisma.categoryUpdateLog.findMany).toHaveBeenCalledWith({
+        where: { categoryId: 'cat-1' },
+        orderBy: { createdAt: 'asc' },
+      })
+    })
+
+    it('로그가 있으면 병합된 업데이트를 반환해야 한다', async () => {
+      // 1. 'Hello'를 추가하는 첫 번째 업데이트 생성
+      const docForUpdate1 = new Y.Doc()
+      docForUpdate1.getText('content').insert(0, 'Hello')
+      const update1 = Y.encodeStateAsUpdate(docForUpdate1)
+
+      // 2. 첫 번째 업데이트 상태에서 ' World'를 추가하는 두 번째 업데이트(diff) 생성
+      const docForUpdate2 = new Y.Doc()
+      Y.applyUpdate(docForUpdate2, update1) // 첫 번째 업데이트 적용
+      docForUpdate2.getText('content').insert(5, ' World')
+      const stateVectorAfter1 = Y.encodeStateVector(docForUpdate1)
+      const update2 = Y.encodeStateAsUpdate(docForUpdate2, stateVectorAfter1) // diff 생성
+
+      // DB에서 순차적인 로그들을 가져온 것처럼 모킹
+      mockPrisma.categoryUpdateLog.findMany.mockResolvedValue([{ updateData: Buffer.from(update1) }, { updateData: Buffer.from(update2) }])
+
+      const result = await repository.getMergedUpdate('cat-1')
+
+      // 병합된 결과 검증
+      const resultDoc = new Y.Doc()
+      Y.applyUpdate(resultDoc, result)
+
+      const content = resultDoc.getText('content').toJSON()
+      expect(content).toBe('Hello World')
+    })
+  })
+
+  describe('saveUpdateLog', () => {
+    it('업데이트 로그를 DB에 저장해야 한다', async () => {
+      const update = new Uint8Array([1, 2, 3])
+
+      await repository.saveUpdateLog('cat-1', update)
+
+      expect(mockPrisma.categoryUpdateLog.create).toHaveBeenCalledWith({
+        data: {
+          categoryId: 'cat-1',
+          updateData: Buffer.from(update),
+        },
+      })
+    })
+  })
+})

--- a/apps/backend/src/modules/canvas/canvas.repository.ts
+++ b/apps/backend/src/modules/canvas/canvas.repository.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common'
+import { PrismaService } from '@/lib/prisma/prisma.service'
+import * as Y from 'yjs'
+
+@Injectable()
+export class CanvasRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 초기 데이터 로드 (DB -> Merged Uint8Array)
+   */
+  async getMergedUpdate(categoryId: string): Promise<Uint8Array> {
+    const logs = await this.prisma.categoryUpdateLog.findMany({
+      where: { categoryId },
+      orderBy: { createdAt: 'asc' },
+    })
+
+    if (logs.length === 0) return new Uint8Array()
+
+    const updates = logs.map(log => new Uint8Array(log.updateData))
+    return Y.mergeUpdates(updates)
+  }
+
+  /**
+   * 업데이트 로그 저장 (Uint8Array -> DB)
+   */
+  async saveUpdateLog(categoryId: string, update: Uint8Array): Promise<void> {
+    await this.prisma.categoryUpdateLog.create({
+      data: {
+        categoryId,
+        updateData: Buffer.from(update),
+      },
+    })
+  }
+}

--- a/apps/backend/src/modules/canvas/canvas.service.spec.ts
+++ b/apps/backend/src/modules/canvas/canvas.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { YjsService } from './yjs.service'
+import { CanvasService } from './canvas.service'
 import { CanvasRepository } from './canvas.repository'
 import { Logger } from '@nestjs/common'
 import * as Y from 'yjs'
@@ -7,7 +7,7 @@ import { CustomException } from '@/lib/exceptions/custom.exception'
 import { ErrorType } from '@/lib/types/response.type'
 
 describe('YjsService', () => {
-  let service: YjsService
+  let service: CanvasService
 
   // Manual Mock 객체 정의
   let mockRepository: {
@@ -27,7 +27,7 @@ describe('YjsService', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        YjsService,
+        CanvasService,
         {
           provide: CanvasRepository,
           useValue: mockRepository, // Manual Mock 주입
@@ -35,7 +35,7 @@ describe('YjsService', () => {
       ],
     }).compile()
 
-    service = module.get<YjsService>(YjsService)
+    service = module.get<CanvasService>(CanvasService)
 
     // Logger 모킹
     jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined)

--- a/apps/backend/src/modules/canvas/canvas.service.ts
+++ b/apps/backend/src/modules/canvas/canvas.service.ts
@@ -12,8 +12,8 @@ interface YjsDocument {
 }
 
 @Injectable()
-export class YjsService implements OnModuleInit, OnModuleDestroy {
-  private readonly logger = new Logger(YjsService.name)
+export class CanvasService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(CanvasService.name)
 
   constructor(private readonly canvasRepository: CanvasRepository) {}
 

--- a/apps/backend/src/modules/canvas/yjs.module.ts
+++ b/apps/backend/src/modules/canvas/yjs.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common'
 import { YjsService } from './yjs.service'
 import { CanvasGateway } from './canvas.gateway'
 import { SocketModule } from '@/modules/socket/socket.module'
+import { CanvasRepository } from './canvas.repository'
 
 @Module({
   imports: [SocketModule],
-  providers: [YjsService, CanvasGateway],
+  providers: [YjsService, CanvasGateway, CanvasRepository],
   exports: [YjsService],
 })
 export class YjsModule {}

--- a/apps/backend/src/modules/canvas/yjs.service.spec.ts
+++ b/apps/backend/src/modules/canvas/yjs.service.spec.ts
@@ -4,6 +4,7 @@ import { CanvasRepository } from './canvas.repository'
 import { Logger } from '@nestjs/common'
 import * as Y from 'yjs'
 import { CustomException } from '@/lib/exceptions/custom.exception'
+import { ErrorType } from '@/lib/types/response.type'
 
 describe('YjsService', () => {
   let service: YjsService
@@ -61,7 +62,6 @@ describe('YjsService', () => {
 
       expect(result.docKey).toBe(`${roomId}-${categoryId}`)
       expect(result.update).toBeDefined()
-
       expect(mockRepository.getMergedUpdate).toHaveBeenCalledWith(categoryId)
     })
 
@@ -82,6 +82,70 @@ describe('YjsService', () => {
 
       // eslint-disable-next-line @typescript-eslint/no-base-to-string
       expect(clientDoc.getText('test').toString()).toBe('hello')
+    })
+
+    it('이미 메모리에 로드된 문서가 있다면 DB 조회 없이 반환해야 한다', async () => {
+      mockRepository.getMergedUpdate.mockResolvedValue(new Uint8Array())
+
+      // 첫 번째 호출 (DB 조회 발생)
+      await service.initializeConnection(roomId, categoryId, socketId)
+
+      // 두 번째 호출 (메모리 캐시 사용)
+      await service.initializeConnection(roomId, categoryId, 'socket-2')
+
+      expect(mockRepository.getMergedUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    it('DB에서 문서 로드 실패 시 InternalServerError 예외를 던져야 한다', async () => {
+      mockRepository.getMergedUpdate.mockRejectedValue(new Error('DB Error'))
+
+      await expect(service.initializeConnection(roomId, categoryId, socketId)).rejects.toThrow(
+        new CustomException(ErrorType.InternalServerError, '캔버스 연결 초기화에 실패했습니다.'),
+      )
+    })
+  })
+
+  describe('connectClient', () => {
+    it('문서가 존재하지 않으면 클라이언트를 연결하지 않아야 한다', () => {
+      // initializeConnection을 호출하지 않고 connectClient 직접 호출
+      service.connectClient('non-existent-cat', 'socket-1')
+
+      // 연결되지 않았으므로 disconnect 시 빈 배열 반환
+      const disconnected = service.disconnectClient('socket-1')
+      expect(disconnected).toEqual([])
+    })
+
+    it('이미 연결된 클라이언트가 같은 카테고리에 다시 연결되어도 중복되지 않아야 한다', async () => {
+      mockRepository.getMergedUpdate.mockResolvedValue(new Uint8Array())
+      await service.initializeConnection('room-1', 'cat-1', 'socket-1')
+
+      // 다시 연결 시도
+      service.connectClient('cat-1', 'socket-1')
+
+      const disconnected = service.disconnectClient('socket-1')
+      expect(disconnected).toHaveLength(1)
+      expect(disconnected).toContain('cat-1')
+    })
+  })
+
+  describe('disconnectClient', () => {
+    it('클라이언트 연결을 해제하고 참여 중이던 캔버스 ID 목록을 반환해야 한다', async () => {
+      const socketId = 'user-1'
+      mockRepository.getMergedUpdate.mockResolvedValue(new Uint8Array())
+
+      await service.initializeConnection('room-1', 'cat-1', socketId)
+      await service.initializeConnection('room-1', 'cat-2', socketId)
+
+      const result = service.disconnectClient(socketId)
+
+      expect(result).toHaveLength(2)
+      expect(result).toContain('cat-1')
+      expect(result).toContain('cat-2')
+    })
+
+    it('연결되지 않은 클라이언트 해제 시 빈 배열을 반환해야 한다', () => {
+      const result = service.disconnectClient('unknown-socket')
+      expect(result).toEqual([])
     })
   })
 
@@ -105,18 +169,30 @@ describe('YjsService', () => {
 
     it('존재하지 않는 캔버스에 업데이트 시 NotFound 예외를 던져야 한다', () => {
       const update = new Uint8Array([0, 0])
-      expect(() => service.processUpdate('invalid-cat', update)).toThrow(CustomException)
+      expect(() => service.processUpdate('invalid-cat', update)).toThrow(
+        new CustomException(ErrorType.NotFound, '활성화된 캔버스 세션을 찾을 수 없습니다. 다시 접속해주세요.'),
+      )
+    })
+
+    it('잘못된 형식의 업데이트 데이터인 경우 BadRequest 예외를 던져야 한다', () => {
+      const invalidUpdate = new Uint8Array([1, 2, 3, 4, 5])
+
+      expect(() => service.processUpdate(categoryId, invalidUpdate)).toThrow(
+        new CustomException(ErrorType.BadRequest, '잘못된 캔버스 데이터 형식입니다.'),
+      )
     })
   })
 
-  describe('Buffer Flush (onModuleInit)', () => {
-    it('일정 주기로 버퍼 내용을 DB에 저장해야 한다', async () => {
-      const roomId = 'room-1'
-      const categoryId = 'cat-1'
+  describe('Buffer Flush (onModuleInit & onModuleDestroy)', () => {
+    const roomId = 'room-1'
+    const categoryId = 'cat-1'
 
+    beforeEach(async () => {
       mockRepository.getMergedUpdate.mockResolvedValue(new Uint8Array())
       await service.initializeConnection(roomId, categoryId, 'socket-1')
+    })
 
+    it('onModuleInit: 일정 주기로 버퍼 내용을 DB에 저장해야 한다', async () => {
       const doc = new Y.Doc()
       doc.getText('t').insert(0, 'a')
       const update = Y.encodeStateAsUpdate(doc)
@@ -127,27 +203,60 @@ describe('YjsService', () => {
 
       // 2. 시간 앞당기기
       jest.advanceTimersByTime(5000)
+      await Promise.resolve() // 마이크로태스크 큐 처리
 
-      // 3. 비동기 콜백(DB 저장)이 완료될 때까지 마이크로태스크 큐 비우기
+      expect(mockRepository.saveUpdateLog).toHaveBeenCalledWith(categoryId, expect.any(Uint8Array))
+    })
+
+    it('onModuleDestroy: 종료 시 버퍼 내용을 DB에 저장해야 한다', async () => {
+      const doc = new Y.Doc()
+      doc.getText('t').insert(0, 'b')
+      const update = Y.encodeStateAsUpdate(doc)
+      service.processUpdate(categoryId, update)
+
+      service.onModuleDestroy()
       await Promise.resolve()
 
       expect(mockRepository.saveUpdateLog).toHaveBeenCalledWith(categoryId, expect.any(Uint8Array))
     })
-  })
 
-  describe('disconnectClient', () => {
-    it('클라이언트 연결을 해제하고 참여 중이던 캔버스 ID 목록을 반환해야 한다', async () => {
-      const socketId = 'user-1'
-      mockRepository.getMergedUpdate.mockResolvedValue(new Uint8Array())
+    it('버퍼가 비어있으면 DB 저장을 수행하지 않아야 한다', async () => {
+      service.onModuleDestroy()
+      await Promise.resolve()
 
-      await service.initializeConnection('room-1', 'cat-1', socketId)
-      await service.initializeConnection('room-1', 'cat-2', socketId)
+      expect(mockRepository.saveUpdateLog).not.toHaveBeenCalled()
+    })
 
-      const result = service.disconnectClient(socketId)
+    it('DB 저장 실패 시 버퍼를 복구해야 하며, 그 사이 들어온 새 데이터도 보존해야 한다', async () => {
+      const doc = new Y.Doc()
+      doc.getText('t').insert(0, 'old')
+      const oldUpdate = Y.encodeStateAsUpdate(doc)
+      service.processUpdate(categoryId, oldUpdate)
 
-      expect(result).toHaveLength(2)
-      expect(result).toContain('cat-1')
-      expect(result).toContain('cat-2')
+      // DB 저장 실패 Mocking
+      mockRepository.saveUpdateLog.mockRejectedValueOnce(new Error('DB Save Error'))
+
+      // private method 호출을 위해 any 캐스팅
+      const flushPromise = service.flushBufferToDB()
+
+      // Flush 도중 새로운 업데이트 발생 시뮬레이션
+      const doc2 = new Y.Doc()
+      doc2.getText('t').insert(0, 'new')
+      const newUpdate = Y.encodeStateAsUpdate(doc2)
+      service.processUpdate(categoryId, newUpdate)
+
+      // Flush 완료 대기
+      await flushPromise
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(Logger.prototype.error).toHaveBeenCalled()
+
+      // 버퍼가 복구되었는지 확인 (old + new)
+      // 다시 Flush 시도하여 verify
+      mockRepository.saveUpdateLog.mockResolvedValueOnce(undefined)
+      await service.flushBufferToDB()
+
+      expect(mockRepository.saveUpdateLog).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/apps/backend/src/modules/canvas/yjs.service.spec.ts
+++ b/apps/backend/src/modules/canvas/yjs.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { YjsService } from './yjs.service'
-import { PrismaService } from '@/lib/prisma/prisma.service'
+import { CanvasRepository } from './canvas.repository'
 import { Logger } from '@nestjs/common'
 import * as Y from 'yjs'
 import { CustomException } from '@/lib/exceptions/custom.exception'
@@ -8,38 +8,33 @@ import { CustomException } from '@/lib/exceptions/custom.exception'
 describe('YjsService', () => {
   let service: YjsService
 
-  // 1. PrismaService의 필요한 메서드만 타입 정의 (Manual Mocking)
-  let prisma: {
-    categoryUpdateLog: {
-      findMany: jest.Mock
-      create: jest.Mock
-    }
+  // Manual Mock 객체 정의
+  let mockRepository: {
+    getMergedUpdate: jest.Mock
+    saveUpdateLog: jest.Mock
   }
 
   beforeEach(async () => {
-    // 2. 타이머 모킹 설정 (각 테스트마다 초기화)
+    // 타이머 모킹 설정 (각 테스트마다 초기화)
     jest.useFakeTimers()
 
-    // 3. Mock 구현체 초기화
-    prisma = {
-      categoryUpdateLog: {
-        findMany: jest.fn(),
-        create: jest.fn(),
-      },
+    // Mock 구현체 초기화
+    mockRepository = {
+      getMergedUpdate: jest.fn(),
+      saveUpdateLog: jest.fn(),
     }
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         YjsService,
         {
-          provide: PrismaService,
-          // 4. 타입 호환성을 위해 강제 단언하여 주입
-          useValue: prisma as unknown as PrismaService,
+          provide: CanvasRepository,
+          useValue: mockRepository, // Manual Mock 주입
         },
       ],
     }).compile()
 
-    service = module.get(YjsService)
+    service = module.get<YjsService>(YjsService)
 
     // Logger 모킹
     jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined)
@@ -59,17 +54,15 @@ describe('YjsService', () => {
     const socketId = 'socket-1'
 
     it('새 문서를 생성하고 초기 업데이트 데이터를 반환해야 한다', async () => {
-      prisma.categoryUpdateLog.findMany.mockResolvedValue([])
+      // spyOn 대신 mock 객체 직접 제어
+      mockRepository.getMergedUpdate.mockResolvedValue(new Uint8Array())
 
       const result = await service.initializeConnection(roomId, categoryId, socketId)
 
       expect(result.docKey).toBe(`${roomId}-${categoryId}`)
       expect(result.update).toBeDefined()
 
-      expect(prisma.categoryUpdateLog.findMany).toHaveBeenCalledWith({
-        where: { categoryId },
-        orderBy: { createdAt: 'asc' },
-      })
+      expect(mockRepository.getMergedUpdate).toHaveBeenCalledWith(categoryId)
     })
 
     it('기존 DB 데이터를 불러와 문서를 초기화해야 한다', async () => {
@@ -77,14 +70,8 @@ describe('YjsService', () => {
       doc.getText('test').insert(0, 'hello')
       const update = Y.encodeStateAsUpdate(doc)
 
-      const mockLog = {
-        id: 1,
-        categoryId,
-        updateData: Buffer.from(update),
-        createdAt: new Date(),
-      }
-
-      prisma.categoryUpdateLog.findMany.mockResolvedValue([mockLog])
+      // YDoc 문서 병합
+      mockRepository.getMergedUpdate.mockResolvedValue(update)
 
       const result = await service.initializeConnection(roomId, categoryId, socketId)
 
@@ -104,7 +91,7 @@ describe('YjsService', () => {
     const socketId = 'socket-1'
 
     beforeEach(async () => {
-      prisma.categoryUpdateLog.findMany.mockResolvedValue([])
+      mockRepository.getMergedUpdate.mockResolvedValue(new Uint8Array())
       await service.initializeConnection(roomId, categoryId, socketId)
     })
 
@@ -127,7 +114,7 @@ describe('YjsService', () => {
       const roomId = 'room-1'
       const categoryId = 'cat-1'
 
-      prisma.categoryUpdateLog.findMany.mockResolvedValue([])
+      mockRepository.getMergedUpdate.mockResolvedValue(new Uint8Array())
       await service.initializeConnection(roomId, categoryId, 'socket-1')
 
       const doc = new Y.Doc()
@@ -141,23 +128,17 @@ describe('YjsService', () => {
       // 2. 시간 앞당기기
       jest.advanceTimersByTime(5000)
 
-      // 3. ✨ 핵심 수정: 비동기 콜백(DB 저장)이 완료될 때까지 마이크로태스크 큐 비우기
+      // 3. 비동기 콜백(DB 저장)이 완료될 때까지 마이크로태스크 큐 비우기
       await Promise.resolve()
 
-      expect(prisma.categoryUpdateLog.create).toHaveBeenCalledWith({
-        data: {
-          categoryId,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          updateData: expect.any(Buffer),
-        },
-      })
+      expect(mockRepository.saveUpdateLog).toHaveBeenCalledWith(categoryId, expect.any(Uint8Array))
     })
   })
 
   describe('disconnectClient', () => {
     it('클라이언트 연결을 해제하고 참여 중이던 캔버스 ID 목록을 반환해야 한다', async () => {
       const socketId = 'user-1'
-      prisma.categoryUpdateLog.findMany.mockResolvedValue([])
+      mockRepository.getMergedUpdate.mockResolvedValue(new Uint8Array())
 
       await service.initializeConnection('room-1', 'cat-1', socketId)
       await service.initializeConnection('room-1', 'cat-2', socketId)

--- a/apps/backend/src/modules/canvas/yjs.service.ts
+++ b/apps/backend/src/modules/canvas/yjs.service.ts
@@ -9,7 +9,6 @@ interface YjsDocument {
   doc: Y.Doc
   roomId: string
   categoryId: string
-  connections: Set<string> // socketId들
 }
 
 @Injectable()
@@ -20,6 +19,9 @@ export class YjsService implements OnModuleInit, OnModuleDestroy {
 
   // categoryId -> YjsDocument 매핑
   private documents = new Map<string, YjsDocument>()
+
+  // socketId -> Set<categoryId> 매핑 (역방향 인덱스)
+  private clientConnections = new Map<string, Set<string>>()
 
   // 업데이트 버퍼: categoryId -> 업데이트 바이너리 배열
   private updateBuffer = new Map<string, Uint8Array[]>()
@@ -69,7 +71,6 @@ export class YjsService implements OnModuleInit, OnModuleDestroy {
       doc,
       roomId,
       categoryId,
-      connections: new Set(),
     })
 
     return doc
@@ -79,24 +80,36 @@ export class YjsService implements OnModuleInit, OnModuleDestroy {
    * 클라이언트를 문서에 연결
    */
   connectClient(categoryId: string, socketId: string) {
-    const yjsDoc = this.documents.get(categoryId)
-    if (yjsDoc) yjsDoc.connections.add(socketId)
+    // 문서가 존재하는지 확인
+    if (this.documents.has(categoryId)) {
+      // 역방향 매핑 업데이트
+      if (!this.clientConnections.has(socketId)) {
+        this.clientConnections.set(socketId, new Set())
+      }
+      this.clientConnections.get(socketId)!.add(categoryId)
+    }
   }
 
   /**
    * 클라이언트 연결 해제
    */
   disconnectClient(socketId: string): string[] {
-    const canvasIds: string[] = []
+    const categoryIds = this.clientConnections.get(socketId)
+    if (!categoryIds) return []
 
-    for (const [, yjsDoc] of this.documents.entries()) {
-      if (yjsDoc.connections.has(socketId)) {
-        yjsDoc.connections.delete(socketId)
-        canvasIds.push(yjsDoc.categoryId)
+    const disconnectedCategories: string[] = []
+
+    for (const categoryId of categoryIds) {
+      // 문서가 메모리에 존재하는지 확인
+      if (this.documents.has(categoryId)) {
+        disconnectedCategories.push(categoryId)
       }
     }
 
-    return canvasIds
+    // 역방향 매핑 제거
+    this.clientConnections.delete(socketId)
+
+    return disconnectedCategories
   }
 
   /**

--- a/apps/backend/src/modules/canvas/yjs.service.ts
+++ b/apps/backend/src/modules/canvas/yjs.service.ts
@@ -1,10 +1,16 @@
 import { CustomException } from '@/lib/exceptions/custom.exception'
 import { ErrorType } from '@/lib/types/response.type'
-import { YjsDocument } from './yjs.type'
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common'
 import * as Y from 'yjs'
 import { encodeStateAsUpdate, applyUpdate } from 'yjs'
 import { CanvasRepository } from './canvas.repository'
+
+interface YjsDocument {
+  doc: Y.Doc
+  roomId: string
+  categoryId: string
+  connections: Set<string> // socketId들
+}
 
 @Injectable()
 export class YjsService implements OnModuleInit, OnModuleDestroy {

--- a/apps/backend/src/modules/canvas/yjs.service.ts
+++ b/apps/backend/src/modules/canvas/yjs.service.ts
@@ -178,7 +178,7 @@ export class YjsService implements OnModuleInit, OnModuleDestroy {
   /**
    * YjsUpdateLog 버퍼 내용을 병합하여 DB에 저장 (Flush)
    */
-  private async flushBufferToDB() {
+  async flushBufferToDB() {
     if (this.updateBuffer.size === 0) return
 
     // 현재 버퍼의 스냅샷을 뜨고 맵을 비움 (동시성 이슈 방지)

--- a/apps/backend/src/modules/canvas/yjs.service.ts
+++ b/apps/backend/src/modules/canvas/yjs.service.ts
@@ -197,8 +197,14 @@ export class YjsService implements OnModuleInit, OnModuleDestroy {
 
         this.logger.log(`[Yjs] Flushed ${updates.length} updates for category ${categoryId}`)
       } catch (err) {
-        this.logger.error(`[Yjs] Failed to flush buffer for ${categoryId}`, err)
-        // TODO: 만약 flush 실패 시 다시 버퍼에 넣거나, 재시도 큐에 넣는 로직 필요
+        this.logger.error(`Flush failed for ${categoryId}, restoring buffer...`, err)
+
+        // [DB Flush 실패 시 업데이트 로그 복구 로직]
+        // 1. 현재 버퍼에 쌓인 데이터 가져오기 (Flush 도중 새로 들어온 데이터)
+        const newUpdates = this.updateBuffer.get(categoryId) || []
+
+        // 2. 실패한 데이터(updates)를 앞에, 새 데이터(newUpdates)를 뒤에 붙여서 복구 (순서: 실패한 과거 데이터 -> 새로 들어온 최신 데이터)
+        this.updateBuffer.set(categoryId, [...updates, ...newUpdates])
       }
     }
   }

--- a/apps/backend/src/modules/canvas/yjs.service.ts
+++ b/apps/backend/src/modules/canvas/yjs.service.ts
@@ -1,16 +1,16 @@
 import { CustomException } from '@/lib/exceptions/custom.exception'
-import { PrismaService } from '@/lib/prisma/prisma.service'
 import { ErrorType } from '@/lib/types/response.type'
 import { YjsDocument } from './yjs.type'
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common'
 import * as Y from 'yjs'
 import { encodeStateAsUpdate, applyUpdate } from 'yjs'
+import { CanvasRepository } from './canvas.repository'
 
 @Injectable()
 export class YjsService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(YjsService.name)
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly canvasRepository: CanvasRepository) {}
 
   // categoryId -> YjsDocument 매핑
   private documents = new Map<string, YjsDocument>()
@@ -50,7 +50,7 @@ export class YjsService implements OnModuleInit, OnModuleDestroy {
 
     try {
       // DB에서 기존 데이터 불러와서 병합
-      const initialUpdate = await this.getMergedUpdate(categoryId)
+      const initialUpdate = await this.canvasRepository.getMergedUpdate(categoryId)
       if (initialUpdate.byteLength > 0) {
         Y.applyUpdate(doc, initialUpdate)
       }
@@ -174,7 +174,7 @@ export class YjsService implements OnModuleInit, OnModuleDestroy {
         const mergedUpdate = Y.mergeUpdates(updates)
 
         // 병합된 하나만 DB에 저장
-        await this.saveUpdateLog(categoryId, mergedUpdate)
+        await this.canvasRepository.saveUpdateLog(categoryId, mergedUpdate)
 
         this.logger.log(`[Yjs] Flushed ${updates.length} updates for category ${categoryId}`)
       } catch (err) {
@@ -182,28 +182,5 @@ export class YjsService implements OnModuleInit, OnModuleDestroy {
         // TODO: 만약 flush 실패 시 다시 버퍼에 넣거나, 재시도 큐에 넣는 로직 필요
       }
     }
-  }
-
-  // 초기 데이터 로드 (DB -> Merged Uint8Array)
-  private async getMergedUpdate(categoryId: string): Promise<Uint8Array> {
-    const logs = await this.prisma.categoryUpdateLog.findMany({
-      where: { categoryId },
-      orderBy: { createdAt: 'asc' },
-    })
-
-    if (logs.length === 0) return new Uint8Array()
-
-    const updates = logs.map(log => new Uint8Array(log.updateData))
-    return Y.mergeUpdates(updates)
-  }
-
-  // 업데이트 로그 저장 (Uint8Array -> DB)
-  private async saveUpdateLog(canvasId: string, update: Uint8Array) {
-    await this.prisma.categoryUpdateLog.create({
-      data: {
-        categoryId: canvasId,
-        updateData: Buffer.from(update),
-      },
-    })
   }
 }

--- a/apps/backend/src/modules/canvas/yjs.type.ts
+++ b/apps/backend/src/modules/canvas/yjs.type.ts
@@ -1,8 +1,0 @@
-import * as Y from 'yjs'
-
-export interface YjsDocument {
-  doc: Y.Doc
-  roomId: string
-  categoryId: string
-  connections: Set<string> // socketId들
-}


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

- Closes #435 

<br>

## 📝 작업 내용
> 작업한 내용을 작성해주세요.

- `yjs.service.ts` 로직의 관심사 분리 (`canvas.repository.ts` 추가)
- 도메인 모듈의 통일성을 위해 파일명 변경 (`yjs.module.ts` -> `canvas.module.ts`)
- 불필요한 모듈화 제거 (`yjs.type.ts`)
- yjs.service.ts 로직 최적화 및 성능 개선
    - `disconnectClient` 로직 및 YjsDocument 객체 최적화
    - `flushBufferToDB` 로직에서 인메모리 버퍼 롤백 기능 구현
- `yjs.service.spec.ts` 테스트 커버리지 향상

<br>

## 🖼️ 스크린샷 (선택)

- [before] 테스트 커버리지
<img width="1503" height="195" alt="image" src="https://github.com/user-attachments/assets/55be3929-efe8-48f6-9c0d-66978632a6f5" />

- [after] 테스트 커버리지

<img width="1508" height="364" alt="image" src="https://github.com/user-attachments/assets/8b5c487b-6d9b-4057-9da0-f6bb1b1bee20" />


<br>

## 테스트 및 검증 내용
> 어떻게 테스트했고, 어떤 결과를 확인했는지 적어주세요.

Jest 테스트 코드 실행

<br>

## 🤔 주요 고민과 해결 과정

- [canvas 모듈 관심사 분리 & 네이밍 통일](https://www.notion.so/canvas-313b3b04c381804d8a6ee96e590efc62?source=copy_link)
- [클라이언트 연결 해제 로직 최적화](https://www.notion.so/disconnectClient-312b3b04c38180c39f32c1711fd88cae?source=copy_link)
- [flushBufferToDB 로직에서 인메모리 버퍼 롤백 기능 구현](https://www.notion.so/flushBufferToDB-313b3b04c381800ebc1ac791c7445aa7?source=copy_link)


<br>

## 💬 리뷰 요구사항 (선택)

놓친 병목 지점이나 성능 저하 포인트가 있다면 같이 검토해주세요!

<br>

## 🧩 참고 사항 (선택)

> 공유하고 싶은 링크나 게시글 등