### PR TITLE
Category 모듈 리팩터링

### DIFF
--- a/apps/backend/src/modules/category/category.gateway.spec.ts
+++ b/apps/backend/src/modules/category/category.gateway.spec.ts
@@ -8,65 +8,86 @@ import { CreateCategoryPayload, DeleteCategoryPayload } from './dto/category.c2s
 describe('CategoryGateway', () => {
   let gateway: CategoryGateway
 
-  const categoryService = {
+  // Mock 객체 정의 (useValue용)
+  const mockCategoryService = {
     createCategory: jest.fn(),
     deleteCategory: jest.fn(),
   }
 
-  const broadcaster = {
+  const mockBroadcaster = {
     setServer: jest.fn(),
+    emitToRoom: jest.fn(),
   }
+
+  // Socket & Server Mock
+  const mockSocket = {
+    id: 'socket-1',
+  } as unknown as Socket
+
+  const mockServer = {} as unknown as Server
+
+  const roomId = 'room-1'
+  const categoryId = 'cat-1'
 
   beforeEach(async () => {
     jest.clearAllMocks()
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CategoryGateway, { provide: CategoryService, useValue: categoryService }, { provide: RoomBroadcaster, useValue: broadcaster }],
+      providers: [
+        CategoryGateway,
+        { provide: CategoryService, useValue: mockCategoryService },
+        { provide: RoomBroadcaster, useValue: mockBroadcaster },
+      ],
     }).compile()
 
-    gateway = module.get(CategoryGateway)
+    gateway = module.get<CategoryGateway>(CategoryGateway)
+
+    // Gateway에 Server 주입 (필요한 경우)
+    gateway.server = mockServer
   })
 
   describe('afterInit', () => {
     it('Gateway 초기화 시 SocketBroadcaster에 서버를 주입한다', () => {
-      const server = {} as Server
-
-      gateway.afterInit(server)
-
-      expect(broadcaster.setServer).toHaveBeenCalledTimes(1)
-      expect(broadcaster.setServer).toHaveBeenCalledWith(server)
+      gateway.afterInit(mockServer)
+      expect(mockBroadcaster.setServer).toHaveBeenCalledWith(mockServer)
     })
   })
 
   describe('onCreateCategory', () => {
-    it('CategoryService.createCategory를 올바른 인자와 함께 호출한다', async () => {
-      const client = {} as Socket
-      const payload: CreateCategoryPayload = {
-        name: '카페',
-      }
+    it('CategoryService를 호출하고 결과를 브로드캐스트한다', async () => {
+      const payload: CreateCategoryPayload = { name: '카페' }
+      const mockCategory = { id: categoryId, title: '카페' }
 
-      // Act
-      await gateway.onCreateCategory(client, payload)
+      mockCategoryService.createCategory.mockResolvedValue({
+        category: mockCategory,
+        roomId,
+      })
 
-      // Assert
-      expect(categoryService.createCategory).toHaveBeenCalledTimes(1)
-      expect(categoryService.createCategory).toHaveBeenCalledWith(client, payload.name)
+      await gateway.onCreateCategory(mockSocket, payload)
+
+      expect(mockCategoryService.createCategory).toHaveBeenCalledWith(mockSocket.id, payload.name)
+      expect(mockBroadcaster.emitToRoom).toHaveBeenCalledWith(roomId, 'category:created', {
+        categoryId: mockCategory.id,
+        name: mockCategory.title,
+      })
     })
   })
 
   describe('onDeleteCategory', () => {
-    it('CategoryService.deleteCategory를 올바른 인자와 함께 호출한다', async () => {
-      const client = {} as Socket
-      const payload: DeleteCategoryPayload = {
-        categoryId: 'c1d2e3f4-a5b6-7890-cdef-0123456789ab',
-      }
+    it('CategoryService를 호출하고 결과를 브로드캐스트한다', async () => {
+      const payload: DeleteCategoryPayload = { categoryId }
 
-      // Act
-      await gateway.onDeleteCategory(client, payload)
+      mockCategoryService.deleteCategory.mockResolvedValue({
+        roomId,
+        categoryId,
+      })
 
-      // Assert
-      expect(categoryService.deleteCategory).toHaveBeenCalledTimes(1)
-      expect(categoryService.deleteCategory).toHaveBeenCalledWith(client, payload.categoryId)
+      await gateway.onDeleteCategory(mockSocket, payload)
+
+      expect(mockCategoryService.deleteCategory).toHaveBeenCalledWith(mockSocket.id, payload.categoryId)
+      expect(mockBroadcaster.emitToRoom).toHaveBeenCalledWith(roomId, 'category:deleted', {
+        categoryId,
+      })
     })
   })
 })

--- a/apps/backend/src/modules/category/category.gateway.ts
+++ b/apps/backend/src/modules/category/category.gateway.ts
@@ -6,6 +6,7 @@ import { Server, Socket } from 'socket.io'
 import { RoomBroadcaster } from '@/modules/socket/room.broadcaster'
 import { CategoryService } from './category.service'
 import { CreateCategoryPayload, DeleteCategoryPayload } from './dto/category.c2s.dto'
+import { CategoryCreatedPayload, CategoryDeletedPayload } from './dto/category.s2c.dto'
 
 @WebSocketGateway({
   namespace: '/room',
@@ -28,11 +29,24 @@ export class CategoryGateway implements OnGatewayInit {
 
   @SubscribeMessage('category:create')
   async onCreateCategory(@ConnectedSocket() client: Socket, @MessageBody() payload: CreateCategoryPayload) {
-    await this.categoryService.createCategory(client, payload.name)
+    const { category, roomId } = await this.categoryService.createCategory(client.id, payload.name)
+
+    const response: CategoryCreatedPayload = {
+      categoryId: category.id,
+      name: category.title,
+    }
+
+    this.broadcaster.emitToRoom(roomId, 'category:created', response)
   }
 
   @SubscribeMessage('category:delete')
   async onDeleteCategory(@ConnectedSocket() client: Socket, @MessageBody() payload: DeleteCategoryPayload) {
-    await this.categoryService.deleteCategory(client, payload.categoryId)
+    const { roomId, categoryId } = await this.categoryService.deleteCategory(client.id, payload.categoryId)
+
+    const response: CategoryDeletedPayload = {
+      categoryId,
+    }
+
+    this.broadcaster.emitToRoom(roomId, 'category:deleted', response)
   }
 }

--- a/apps/backend/src/modules/category/category.repository.spec.ts
+++ b/apps/backend/src/modules/category/category.repository.spec.ts
@@ -3,19 +3,41 @@ import type { Category } from '@prisma/client'
 
 import { PrismaService } from '@/lib/prisma/prisma.service'
 import { CategoryRepository } from './category.repository'
+import { CustomException } from '@/lib/exceptions/custom.exception'
+import { ErrorType } from '@/lib/types/response.type'
+
+type MockPrismaService = {
+  category: {
+    findMany: jest.Mock
+    create: jest.Mock
+    delete: jest.Mock
+    count: jest.Mock
+    findFirst: jest.Mock
+  }
+  $transaction: jest.Mock
+}
 
 describe('CategoryRepository', () => {
   let repository: CategoryRepository
-  let prisma: { category: { findMany: jest.Mock; create: jest.Mock; delete: jest.Mock } }
+  let prisma: MockPrismaService
 
   beforeEach(async () => {
-    prisma = {
+    const mockPrisma = {
       category: {
         findMany: jest.fn(),
         create: jest.fn(),
         delete: jest.fn(),
+        count: jest.fn(),
+        findFirst: jest.fn(),
       },
+      $transaction: jest.fn(),
     }
+
+    mockPrisma.$transaction.mockImplementation((callback: (tx: typeof mockPrisma) => Promise<any>) => {
+      return callback(mockPrisma)
+    })
+
+    prisma = mockPrisma as unknown as MockPrismaService
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [CategoryRepository, { provide: PrismaService, useValue: prisma }],
@@ -43,107 +65,81 @@ describe('CategoryRepository', () => {
         orderBy: { orderIndex: 'asc' },
       })
     })
+  })
 
-    it('해당 roomId에 카테고리가 없으면 빈 배열을 반환한다', async () => {
-      const roomId = 'empty-room'
+  describe('createWithLimit', () => {
+    it('카테고리 개수가 제한을 초과하면 예외를 던진다', async () => {
+      const roomId = 'room-1'
+      const title = '새 카테고리'
+      const limit = 10
 
-      prisma.category.findMany.mockResolvedValue([])
+      prisma.category.count.mockResolvedValue(10)
 
-      const result = await repository.findByRoomId(roomId)
-
-      expect(result).toEqual([])
-      expect(prisma.category.findMany).toHaveBeenCalledWith({
-        where: { roomId },
-        orderBy: { orderIndex: 'asc' },
-      })
-    })
-
-    it('orderIndex 오름차순으로 정렬하여 조회한다', async () => {
-      const roomId = 'a3k9m2x7'
-
-      prisma.category.findMany.mockResolvedValue([])
-
-      await repository.findByRoomId(roomId)
-
-      expect(prisma.category.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          orderBy: { orderIndex: 'asc' },
-        }),
+      await expect(repository.createWithLimit({ roomId, title }, limit)).rejects.toThrow(
+        new CustomException(ErrorType.CategoryOverFlowException, `카테고리 개수 제한을 초과했습니다. (최대 ${limit}개)`),
       )
     })
-  })
 
-  describe('create', () => {
-    it('카테고리를 생성한다', async () => {
-      const roomId = 'a3k9m2x7'
-      const title = '카페'
+    it('카테고리를 생성하고 반환한다', async () => {
+      const roomId = 'room-1'
+      const title = '새 카테고리'
+      const limit = 10
       const now = new Date()
       const createdCategory: Category = {
-        id: '6d739f00-5bbc-4a0a-8ace-58d27fca0c93',
+        id: 'cat-1',
         roomId,
         title,
-        orderIndex: 0,
+        orderIndex: 1,
         createdAt: now,
       }
 
+      prisma.category.count.mockResolvedValue(5)
+      prisma.category.findFirst.mockResolvedValue({ orderIndex: 0 })
       prisma.category.create.mockResolvedValue(createdCategory)
 
-      const result = await repository.create({ roomId, title })
+      const result = await repository.createWithLimit({ roomId, title }, limit)
 
       expect(result).toEqual(createdCategory)
       expect(prisma.category.create).toHaveBeenCalledWith({
         data: {
           roomId,
           title,
-          orderIndex: 0,
-        },
-      })
-    })
-
-    it('orderIndex를 명시적으로 전달하면 해당 값으로 생성한다', async () => {
-      const roomId = 'a3k9m2x7'
-      const title = '음식'
-      const orderIndex = 5
-      const now = new Date()
-      const createdCategory: Category = {
-        id: '6d739f00-5bbc-4a0a-8ace-58d27fca0c93',
-        roomId,
-        title,
-        orderIndex,
-        createdAt: now,
-      }
-
-      prisma.category.create.mockResolvedValue(createdCategory)
-
-      const result = await repository.create({ roomId, title, orderIndex })
-
-      expect(result).toEqual(createdCategory)
-      expect(prisma.category.create).toHaveBeenCalledWith({
-        data: {
-          roomId,
-          title,
-          orderIndex,
+          orderIndex: 1,
         },
       })
     })
   })
 
-  describe('delete', () => {
-    it('카테고리를 삭제한다', async () => {
-      const categoryId = '6d739f00-5bbc-4a0a-8ace-58d27fca0c93'
-      const roomId = 'a3k9m2x7'
+  describe('deleteWithLimit', () => {
+    it('카테고리 개수가 최소 제한 이하이면 예외를 던진다', async () => {
+      const roomId = 'room-1'
+      const categoryId = 'cat-1'
+      const minLimit = 1
+
+      prisma.category.count.mockResolvedValue(1)
+
+      await expect(repository.deleteWithLimit(categoryId, roomId, minLimit)).rejects.toThrow(
+        new CustomException(ErrorType.BadRequest, `최소 ${minLimit}개의 카테고리는 유지해야 합니다.`),
+      )
+    })
+
+    it('카테고리를 삭제하고 반환한다', async () => {
+      const roomId = 'room-1'
+      const categoryId = 'cat-1'
+      const minLimit = 1
       const now = new Date()
       const deletedCategory: Category = {
         id: categoryId,
         roomId,
-        title: '카페',
+        title: '삭제된 카테고리',
         orderIndex: 0,
         createdAt: now,
       }
 
+      prisma.category.count.mockResolvedValue(2)
       prisma.category.delete.mockResolvedValue(deletedCategory)
 
-      const result = await repository.delete(categoryId)
+      const result = await repository.deleteWithLimit(categoryId, roomId, minLimit)
 
       expect(result).toEqual(deletedCategory)
       expect(prisma.category.delete).toHaveBeenCalledWith({

--- a/apps/backend/src/modules/category/category.repository.spec.ts
+++ b/apps/backend/src/modules/category/category.repository.spec.ts
@@ -137,6 +137,7 @@ describe('CategoryRepository', () => {
       }
 
       prisma.category.count.mockResolvedValue(2)
+      prisma.category.findFirst.mockResolvedValue(deletedCategory)
       prisma.category.delete.mockResolvedValue(deletedCategory)
 
       const result = await repository.deleteWithLimit(categoryId, roomId, minLimit)

--- a/apps/backend/src/modules/category/category.repository.ts
+++ b/apps/backend/src/modules/category/category.repository.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common'
 import { Category } from '@prisma/client'
 import { PrismaService } from '@/lib/prisma/prisma.service'
+import { CustomException } from '@/lib/exceptions/custom.exception'
+import { ErrorType } from '@/lib/types/response.type'
 
 @Injectable()
 export class CategoryRepository {
@@ -13,19 +15,53 @@ export class CategoryRepository {
     })
   }
 
-  async create(data: { roomId: string; title: string; orderIndex?: number }): Promise<Category> {
-    return this.prisma.category.create({
-      data: {
-        roomId: data.roomId,
-        title: data.title,
-        orderIndex: data.orderIndex ?? 0,
-      },
+  async count(roomId: string): Promise<number> {
+    return this.prisma.category.count({
+      where: { roomId },
     })
   }
 
-  async delete(id: string): Promise<Category> {
-    return this.prisma.category.delete({
-      where: { id },
+  async createWithLimit(data: { roomId: string; title: string }, limit: number): Promise<Category> {
+    return this.prisma.$transaction(async tx => {
+      const count = await tx.category.count({
+        where: { roomId: data.roomId },
+      })
+
+      if (count >= limit) {
+        throw new CustomException(ErrorType.CategoryOverFlowException, `카테고리 개수 제한을 초과했습니다. (최대 ${limit}개)`)
+      }
+
+      const maxOrderIndex = await tx.category.findFirst({
+        where: { roomId: data.roomId },
+        orderBy: { orderIndex: 'desc' },
+        select: { orderIndex: true },
+      })
+
+      const orderIndex = (maxOrderIndex?.orderIndex ?? -1) + 1
+
+      return tx.category.create({
+        data: {
+          roomId: data.roomId,
+          title: data.title,
+          orderIndex,
+        },
+      })
+    })
+  }
+
+  async deleteWithLimit(id: string, roomId: string, minLimit: number): Promise<Category> {
+    return this.prisma.$transaction(async tx => {
+      const count = await tx.category.count({
+        where: { roomId },
+      })
+
+      if (count <= minLimit) {
+        throw new CustomException(ErrorType.BadRequest, `최소 ${minLimit}개의 카테고리는 유지해야 합니다.`)
+      }
+
+      return tx.category.delete({
+        where: { id },
+      })
     })
   }
 }

--- a/apps/backend/src/modules/category/category.repository.ts
+++ b/apps/backend/src/modules/category/category.repository.ts
@@ -59,8 +59,14 @@ export class CategoryRepository {
         throw new CustomException(ErrorType.BadRequest, `최소 ${minLimit}개의 카테고리는 유지해야 합니다.`)
       }
 
+      const target = await tx.category.findFirst({
+        where: { id, roomId },
+      })
+      if (!target) {
+        throw new CustomException(ErrorType.NotFound, '삭제할 카테고리를 찾을 수 없습니다.')
+      }
       return tx.category.delete({
-        where: { id },
+        where: { id: target.id },
       })
     })
   }

--- a/apps/backend/src/modules/category/category.service.spec.ts
+++ b/apps/backend/src/modules/category/category.service.spec.ts
@@ -1,60 +1,39 @@
 import { CustomException } from '@/lib/exceptions/custom.exception'
 import { ErrorType } from '@/lib/types/response.type'
 import { Test, TestingModule } from '@nestjs/testing'
-import type { Socket } from 'socket.io'
 import { CategoryRepository } from './category.repository'
-import { RoomBroadcaster } from '@/modules/socket/room.broadcaster'
 import { UserService } from '@/modules/user/user.service'
-import type { UserSession } from '@/modules/user/user.type'
 import { CategoryService } from './category.service'
 
-describe('CategoryService (socket handlers only)', () => {
+describe('CategoryService', () => {
   let service: CategoryService
 
-  const roomId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
-  const categoryId = 'c1d2e3f4-a5b6-7890-cdef-0123456789ab'
-  const socketId = 'socket-123'
-  const now = new Date('2026-01-15T00:00:00.000Z')
+  // Mock 객체 정의 (useValue용)
+  const mockCategoryRepository = {
+    findByRoomId: jest.fn(),
+    create: jest.fn(),
+    delete: jest.fn(),
+  }
+
+  const mockUserService = {
+    getSession: jest.fn(),
+  }
+
+  const roomId = 'room-1'
+  const categoryId = 'cat-1'
+  const socketId = 'socket-1'
 
   const mockCategory = {
     id: categoryId,
     roomId,
     title: '카페',
     orderIndex: 0,
-    createdAt: now,
   }
 
-  const mockUserSession: UserSession = {
-    socketId,
-    userId: 'user-1',
-    name: '테스트 사용자',
-    color: 'hsl(120, 70%, 50%)',
+  const mockSession = {
     roomId,
-    joinedAt: now,
-    isOwner: false,
+    socketId,
   }
-
-  const categoryRepositoryMock = {
-    findByRoomId: jest.fn(),
-    create: jest.fn(),
-    delete: jest.fn(),
-  }
-
-  const emitToRoomMock = jest.fn()
-  const broadcasterMock = {
-    emitToRoom: emitToRoomMock,
-  }
-
-  const getSessionMock = jest.fn()
-  const userServiceMock = {
-    getSession: getSessionMock,
-  }
-
-  const clientEmitMock = jest.fn() as (event: string, ...args: unknown[]) => boolean
-  const mockClient = {
-    id: socketId,
-    emit: clientEmitMock,
-  } as unknown as Socket
 
   beforeEach(async () => {
     jest.clearAllMocks()
@@ -62,169 +41,84 @@ describe('CategoryService (socket handlers only)', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CategoryService,
-        { provide: CategoryRepository, useValue: categoryRepositoryMock },
-        { provide: RoomBroadcaster, useValue: broadcasterMock },
-        { provide: UserService, useValue: userServiceMock },
+        { provide: CategoryRepository, useValue: mockCategoryRepository },
+        { provide: UserService, useValue: mockUserService },
       ],
     }).compile()
 
-    service = module.get(CategoryService)
-  })
-
-  describe('findByRoomId', () => {
-    it('roomId로 카테고리 목록을 조회한다', async () => {
-      categoryRepositoryMock.findByRoomId.mockResolvedValue([mockCategory])
-
-      const result = await service.findByRoomId(roomId)
-
-      expect(result).toEqual([mockCategory])
-      expect(categoryRepositoryMock.findByRoomId).toHaveBeenCalledWith(roomId)
-    })
+    service = module.get<CategoryService>(CategoryService)
   })
 
   describe('createCategory', () => {
     it('세션이 없으면 NotInRoom 예외를 던진다', async () => {
-      getSessionMock.mockReturnValue(undefined)
+      mockUserService.getSession.mockReturnValue(null)
 
-      await expect(service.createCategory(mockClient, '음식')).rejects.toThrow(new CustomException(ErrorType.NotInRoom, '방에 참여하지 않았습니다.'))
-
-      expect(categoryRepositoryMock.create).not.toHaveBeenCalled()
-      expect(emitToRoomMock).not.toHaveBeenCalled()
-    })
-
-    it('카테고리를 생성하고 브로드캐스트한다 (orderIndex=0)', async () => {
-      const name = '음식'
-      getSessionMock.mockReturnValue(mockUserSession)
-      categoryRepositoryMock.findByRoomId.mockResolvedValue([])
-      categoryRepositoryMock.create.mockResolvedValue({ ...mockCategory, title: name, orderIndex: 0 })
-
-      await service.createCategory(mockClient, name)
-
-      expect(getSessionMock).toHaveBeenCalledWith(socketId)
-      expect(categoryRepositoryMock.findByRoomId).toHaveBeenCalledWith(roomId)
-      expect(categoryRepositoryMock.create).toHaveBeenCalledWith({
-        roomId,
-        title: name,
-        orderIndex: 0,
-      })
-      expect(emitToRoomMock).toHaveBeenCalledWith(roomId, 'category:created', {
-        categoryId,
-        name,
-      })
-      expect(clientEmitMock).not.toHaveBeenCalled()
-    })
-
-    it('기존 카테고리가 있으면 orderIndex를 최대값+1로 생성한다', async () => {
-      const name = '음식'
-      getSessionMock.mockReturnValue(mockUserSession)
-
-      const existing = [
-        { ...mockCategory, id: 'c-1', orderIndex: 0 },
-        { ...mockCategory, id: 'c-2', orderIndex: 2 },
-      ]
-      categoryRepositoryMock.findByRoomId.mockResolvedValue(existing)
-      categoryRepositoryMock.create.mockResolvedValue({ ...mockCategory, title: name, orderIndex: 3 })
-
-      await service.createCategory(mockClient, name)
-
-      expect(categoryRepositoryMock.create).toHaveBeenCalledWith({
-        roomId,
-        title: name,
-        orderIndex: 3,
-      })
-      expect(emitToRoomMock).toHaveBeenCalledWith(roomId, 'category:created', {
-        categoryId,
-        name,
-      })
+      await expect(service.createCategory(socketId, '새 카테고리')).rejects.toThrow(
+        new CustomException(ErrorType.NotInRoom, '방에 참여하지 않았습니다.'),
+      )
     })
 
     it('카테고리가 10개 이상이면 CategoryOverFlowException 예외를 던진다', async () => {
-      getSessionMock.mockReturnValue(mockUserSession)
+      mockUserService.getSession.mockReturnValue(mockSession)
+      mockCategoryRepository.findByRoomId.mockResolvedValue(new Array(10).fill(mockCategory))
 
-      const existing = Array.from({ length: 10 }, (_, i) => ({
-        ...mockCategory,
-        id: `c-${i}`,
-        orderIndex: i,
-      }))
-      categoryRepositoryMock.findByRoomId.mockResolvedValue(existing)
+      await expect(service.createCategory(socketId, '새 카테고리')).rejects.toThrow(
+        new CustomException(ErrorType.CategoryOverFlowException, '카테고리 개수 제한을 초과했습니다. (최대 10개)'),
+      )
+    })
 
-      await expect(service.createCategory(mockClient, '음식')).rejects.toThrow(CustomException)
+    it('카테고리를 생성하고 반환한다', async () => {
+      mockUserService.getSession.mockReturnValue(mockSession)
+      mockCategoryRepository.findByRoomId.mockResolvedValue([])
+      mockCategoryRepository.create.mockResolvedValue(mockCategory)
 
-      try {
-        await service.createCategory(mockClient, '음식')
-      } catch (e) {
-        expect(e).toBeInstanceOf(CustomException)
-        expect((e as CustomException).type).toBe(ErrorType.CategoryOverFlowException)
-      }
+      const result = await service.createCategory(socketId, '새 카테고리')
 
-      expect(categoryRepositoryMock.create).not.toHaveBeenCalled()
-      expect(emitToRoomMock).not.toHaveBeenCalled()
+      expect(result).toEqual({ category: mockCategory, roomId })
+      expect(mockCategoryRepository.create).toHaveBeenCalledWith({
+        roomId,
+        title: '새 카테고리',
+        orderIndex: 0,
+      })
     })
   })
 
   describe('deleteCategory', () => {
     it('세션이 없으면 NotInRoom 예외를 던진다', async () => {
-      getSessionMock.mockReturnValue(undefined)
+      mockUserService.getSession.mockReturnValue(null)
 
-      await expect(service.deleteCategory(mockClient, categoryId)).rejects.toThrow(
+      await expect(service.deleteCategory(socketId, categoryId)).rejects.toThrow(
         new CustomException(ErrorType.NotInRoom, '방에 참여하지 않았습니다.'),
       )
-
-      expect(categoryRepositoryMock.delete).not.toHaveBeenCalled()
-    })
-
-    it('카테고리를 삭제하고 브로드캐스트한다', async () => {
-      getSessionMock.mockReturnValue(mockUserSession)
-      categoryRepositoryMock.findByRoomId.mockResolvedValue([
-        { ...mockCategory, id: categoryId },
-        { ...mockCategory, id: 'c-2' },
-      ])
-      categoryRepositoryMock.delete.mockResolvedValue(mockCategory)
-
-      await service.deleteCategory(mockClient, categoryId)
-
-      expect(categoryRepositoryMock.findByRoomId).toHaveBeenCalledWith(roomId)
-      expect(categoryRepositoryMock.delete).toHaveBeenCalledWith(categoryId)
-
-      expect(emitToRoomMock).toHaveBeenCalledWith(roomId, 'category:deleted', {
-        categoryId,
-      })
-      expect(clientEmitMock).not.toHaveBeenCalled()
     })
 
     it('카테고리가 1개 이하면 BadRequest 예외를 던진다', async () => {
-      getSessionMock.mockReturnValue(mockUserSession)
-      // 1개만 남은 상황 설정
-      categoryRepositoryMock.findByRoomId.mockResolvedValue([{ ...mockCategory, id: categoryId }])
+      mockUserService.getSession.mockReturnValue(mockSession)
+      mockCategoryRepository.findByRoomId.mockResolvedValue([mockCategory])
 
-      await expect(service.deleteCategory(mockClient, categoryId)).rejects.toThrow(CustomException)
-
-      try {
-        await service.deleteCategory(mockClient, categoryId)
-      } catch (e) {
-        expect((e as CustomException).type).toBe(ErrorType.BadRequest)
-      }
-
-      expect(categoryRepositoryMock.delete).not.toHaveBeenCalled()
+      await expect(service.deleteCategory(socketId, categoryId)).rejects.toThrow(
+        new CustomException(ErrorType.BadRequest, '최소 1개의 카테고리는 유지해야 합니다.'),
+      )
     })
 
-    it('삭제할 카테고리가 목록에 없으면 NotFound 예외를 던진다', async () => {
-      getSessionMock.mockReturnValue(mockUserSession)
-      // 목록에는 존재하지만 삭제하려는 ID와 다른 카테고리만 있음
-      categoryRepositoryMock.findByRoomId.mockResolvedValue([
-        { ...mockCategory, id: 'other-category-id' },
-        { ...mockCategory, id: 'another-id' },
-      ])
+    it('삭제할 카테고리가 없으면 NotFound 예외를 던진다', async () => {
+      mockUserService.getSession.mockReturnValue(mockSession)
+      mockCategoryRepository.findByRoomId.mockResolvedValue([mockCategory, { ...mockCategory, id: 'other' }])
 
-      await expect(service.deleteCategory(mockClient, categoryId)).rejects.toThrow(CustomException)
+      await expect(service.deleteCategory(socketId, 'non-existent')).rejects.toThrow(
+        new CustomException(ErrorType.NotFound, '삭제할 카테고리를 찾을 수 없습니다.'),
+      )
+    })
 
-      try {
-        await service.deleteCategory(mockClient, categoryId)
-      } catch (e) {
-        expect((e as CustomException).type).toBe(ErrorType.NotFound)
-      }
+    it('카테고리를 삭제하고 반환한다', async () => {
+      mockUserService.getSession.mockReturnValue(mockSession)
+      mockCategoryRepository.findByRoomId.mockResolvedValue([mockCategory, { ...mockCategory, id: 'other' }])
+      mockCategoryRepository.delete.mockResolvedValue(mockCategory)
 
-      expect(categoryRepositoryMock.delete).not.toHaveBeenCalled()
+      const result = await service.deleteCategory(socketId, categoryId)
+
+      expect(result).toEqual({ roomId, categoryId })
+      expect(mockCategoryRepository.delete).toHaveBeenCalledWith(categoryId)
     })
   })
 })

--- a/apps/backend/src/modules/category/category.service.spec.ts
+++ b/apps/backend/src/modules/category/category.service.spec.ts
@@ -1,6 +1,7 @@
 import { CustomException } from '@/lib/exceptions/custom.exception'
 import { ErrorType } from '@/lib/types/response.type'
 import { Test, TestingModule } from '@nestjs/testing'
+import { Prisma } from '@prisma/client'
 import { CategoryRepository } from './category.repository'
 import { UserService } from '@/modules/user/user.service'
 import { CategoryService } from './category.service'
@@ -11,8 +12,8 @@ describe('CategoryService', () => {
   // Mock 객체 정의 (useValue용)
   const mockCategoryRepository = {
     findByRoomId: jest.fn(),
-    create: jest.fn(),
-    delete: jest.fn(),
+    createWithLimit: jest.fn(),
+    deleteWithLimit: jest.fn(),
   }
 
   const mockUserService = {
@@ -26,7 +27,7 @@ describe('CategoryService', () => {
   const mockCategory = {
     id: categoryId,
     roomId,
-    title: '카페',
+    title: '기본',
     orderIndex: 0,
   }
 
@@ -60,7 +61,9 @@ describe('CategoryService', () => {
 
     it('카테고리가 10개 이상이면 CategoryOverFlowException 예외를 던진다', async () => {
       mockUserService.getSession.mockReturnValue(mockSession)
-      mockCategoryRepository.findByRoomId.mockResolvedValue(new Array(10).fill(mockCategory))
+      mockCategoryRepository.createWithLimit.mockRejectedValue(
+        new CustomException(ErrorType.CategoryOverFlowException, '카테고리 개수 제한을 초과했습니다. (최대 10개)'),
+      )
 
       await expect(service.createCategory(socketId, '새 카테고리')).rejects.toThrow(
         new CustomException(ErrorType.CategoryOverFlowException, '카테고리 개수 제한을 초과했습니다. (최대 10개)'),
@@ -69,17 +72,18 @@ describe('CategoryService', () => {
 
     it('카테고리를 생성하고 반환한다', async () => {
       mockUserService.getSession.mockReturnValue(mockSession)
-      mockCategoryRepository.findByRoomId.mockResolvedValue([])
-      mockCategoryRepository.create.mockResolvedValue(mockCategory)
+      mockCategoryRepository.createWithLimit.mockResolvedValue(mockCategory)
 
       const result = await service.createCategory(socketId, '새 카테고리')
 
       expect(result).toEqual({ category: mockCategory, roomId })
-      expect(mockCategoryRepository.create).toHaveBeenCalledWith({
-        roomId,
-        title: '새 카테고리',
-        orderIndex: 0,
-      })
+      expect(mockCategoryRepository.createWithLimit).toHaveBeenCalledWith(
+        {
+          roomId,
+          title: '새 카테고리',
+        },
+        10,
+      )
     })
   })
 
@@ -94,7 +98,7 @@ describe('CategoryService', () => {
 
     it('카테고리가 1개 이하면 BadRequest 예외를 던진다', async () => {
       mockUserService.getSession.mockReturnValue(mockSession)
-      mockCategoryRepository.findByRoomId.mockResolvedValue([mockCategory])
+      mockCategoryRepository.deleteWithLimit.mockRejectedValue(new CustomException(ErrorType.BadRequest, '최소 1개의 카테고리는 유지해야 합니다.'))
 
       await expect(service.deleteCategory(socketId, categoryId)).rejects.toThrow(
         new CustomException(ErrorType.BadRequest, '최소 1개의 카테고리는 유지해야 합니다.'),
@@ -103,7 +107,11 @@ describe('CategoryService', () => {
 
     it('삭제할 카테고리가 없으면 NotFound 예외를 던진다', async () => {
       mockUserService.getSession.mockReturnValue(mockSession)
-      mockCategoryRepository.findByRoomId.mockResolvedValue([mockCategory, { ...mockCategory, id: 'other' }])
+      const error = new Prisma.PrismaClientKnownRequestError('Not Found', {
+        code: 'P2025',
+        clientVersion: '5.0.0',
+      })
+      mockCategoryRepository.deleteWithLimit.mockRejectedValue(error)
 
       await expect(service.deleteCategory(socketId, 'non-existent')).rejects.toThrow(
         new CustomException(ErrorType.NotFound, '삭제할 카테고리를 찾을 수 없습니다.'),
@@ -112,13 +120,12 @@ describe('CategoryService', () => {
 
     it('카테고리를 삭제하고 반환한다', async () => {
       mockUserService.getSession.mockReturnValue(mockSession)
-      mockCategoryRepository.findByRoomId.mockResolvedValue([mockCategory, { ...mockCategory, id: 'other' }])
-      mockCategoryRepository.delete.mockResolvedValue(mockCategory)
+      mockCategoryRepository.deleteWithLimit.mockResolvedValue(mockCategory)
 
       const result = await service.deleteCategory(socketId, categoryId)
 
       expect(result).toEqual({ roomId, categoryId })
-      expect(mockCategoryRepository.delete).toHaveBeenCalledWith(categoryId)
+      expect(mockCategoryRepository.deleteWithLimit).toHaveBeenCalledWith(categoryId, roomId, 1)
     })
   })
 })

--- a/apps/backend/src/modules/category/category.service.ts
+++ b/apps/backend/src/modules/category/category.service.ts
@@ -1,7 +1,7 @@
 import { CustomException } from '@/lib/exceptions/custom.exception'
 import { ErrorType } from '@/lib/types/response.type'
 import { Injectable } from '@nestjs/common'
-import { Category } from '@prisma/client'
+import { Category, Prisma } from '@prisma/client'
 import { UserService } from '@/modules/user/user.service'
 import { CategoryRepository } from './category.repository'
 
@@ -23,19 +23,13 @@ export class CategoryService {
       throw new CustomException(ErrorType.NotInRoom, '방에 참여하지 않았습니다.')
     }
 
-    const existingCategories = await this.categoryRepository.findByRoomId(session.roomId)
-    if (existingCategories.length >= 10) {
-      throw new CustomException(ErrorType.CategoryOverFlowException, '카테고리 개수 제한을 초과했습니다. (최대 10개)')
-    }
-
-    const maxOrderIndex = existingCategories.reduce((max, cat) => Math.max(max, cat.orderIndex), -1)
-    const orderIndex = maxOrderIndex + 1
-
-    const category = await this.categoryRepository.create({
-      roomId: session.roomId,
-      title: name,
-      orderIndex,
-    })
+    const category = await this.categoryRepository.createWithLimit(
+      {
+        roomId: session.roomId,
+        title: name,
+      },
+      10,
+    )
 
     return { category, roomId: session.roomId }
   }
@@ -47,18 +41,14 @@ export class CategoryService {
       throw new CustomException(ErrorType.NotInRoom, '방에 참여하지 않았습니다.')
     }
 
-    const existingCategories = await this.categoryRepository.findByRoomId(session.roomId)
-
-    if (existingCategories.length <= 1) {
-      throw new CustomException(ErrorType.BadRequest, '최소 1개의 카테고리는 유지해야 합니다.')
+    try {
+      await this.categoryRepository.deleteWithLimit(categoryId, session.roomId, 1)
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+        throw new CustomException(ErrorType.NotFound, '삭제할 카테고리를 찾을 수 없습니다.')
+      }
+      throw error
     }
-
-    const targetCategory = existingCategories.find(c => c.id === categoryId)
-    if (!targetCategory) {
-      throw new CustomException(ErrorType.NotFound, '삭제할 카테고리를 찾을 수 없습니다.')
-    }
-
-    await this.categoryRepository.delete(categoryId)
 
     return { roomId: session.roomId, categoryId }
   }

--- a/apps/backend/src/modules/category/category.service.ts
+++ b/apps/backend/src/modules/category/category.service.ts
@@ -2,17 +2,13 @@ import { CustomException } from '@/lib/exceptions/custom.exception'
 import { ErrorType } from '@/lib/types/response.type'
 import { Injectable } from '@nestjs/common'
 import { Category } from '@prisma/client'
-import type { Socket } from 'socket.io'
-import { RoomBroadcaster } from '@/modules/socket/room.broadcaster'
 import { UserService } from '@/modules/user/user.service'
 import { CategoryRepository } from './category.repository'
-import { CategoryCreatedPayload, CategoryDeletedPayload } from './dto/category.s2c.dto'
 
 @Injectable()
 export class CategoryService {
   constructor(
     private readonly categoryRepository: CategoryRepository,
-    private readonly broadcaster: RoomBroadcaster,
     private readonly userService: UserService,
   ) {}
 
@@ -20,10 +16,12 @@ export class CategoryService {
     return this.categoryRepository.findByRoomId(roomId)
   }
 
-  async createCategory(client: Socket, name: string) {
-    const session = this.userService.getSession(client.id)
+  async createCategory(clientId: string, name: string): Promise<{ category: Category; roomId: string }> {
+    const session = this.userService.getSession(clientId)
 
-    if (!session) throw new CustomException(ErrorType.NotInRoom, '방에 참여하지 않았습니다.')
+    if (!session) {
+      throw new CustomException(ErrorType.NotInRoom, '방에 참여하지 않았습니다.')
+    }
 
     const existingCategories = await this.categoryRepository.findByRoomId(session.roomId)
     if (existingCategories.length >= 10) {
@@ -39,18 +37,15 @@ export class CategoryService {
       orderIndex,
     })
 
-    const response: CategoryCreatedPayload = {
-      categoryId: category.id,
-      name: category.title,
-    }
-
-    this.broadcaster.emitToRoom(category.roomId, 'category:created', response)
+    return { category, roomId: session.roomId }
   }
 
-  async deleteCategory(client: Socket, categoryId: string) {
-    const session = this.userService.getSession(client.id)
+  async deleteCategory(clientId: string, categoryId: string): Promise<{ roomId: string; categoryId: string }> {
+    const session = this.userService.getSession(clientId)
 
-    if (!session) throw new CustomException(ErrorType.NotInRoom, '방에 참여하지 않았습니다.')
+    if (!session) {
+      throw new CustomException(ErrorType.NotInRoom, '방에 참여하지 않았습니다.')
+    }
 
     const existingCategories = await this.categoryRepository.findByRoomId(session.roomId)
 
@@ -65,10 +60,6 @@ export class CategoryService {
 
     await this.categoryRepository.delete(categoryId)
 
-    const response: CategoryDeletedPayload = {
-      categoryId,
-    }
-
-    this.broadcaster.emitToRoom(session.roomId, 'category:deleted', response)
+    return { roomId: session.roomId, categoryId }
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

- Closes #440 

<br>

## 📝 작업 내용

### 주요 작업

1. 관심사의 분리
    - `CategoryService`: Socket 및 RoomBroadcaster 의존성 제거, 순수 비즈니스 로직만 남김.
    - `CategoryGateway`: CategoryService 호출 후 반환값을 받아 브로드캐스팅 수행.
2. 동시성 문제 해결 및 성능 최적화 (`category.service.ts`)
    - 동시성 문제 해결 : 트랜잭션을 사용하여 개수 확인과 생성/삭제를 원자적으로 처리
    - 쿼리 최적화: 불필요한 전체 목록 조회 대신 `count`, `findFirst` 등을 사용

### Lesson Learn (무엇을 배웠는가!)

- Spring에서 하던 방식처럼, DML에서 읽기가 아닌 **쓰기 로직에서는 왠만하면 Transaction을 거는 것**이 매우 안전함!
- 그럼 쓰기 로직에서 transaction을 안거는 경우가 존재할까? (아예 없는 줄 알았더니 서비스의 목적과 상황에 따라 존재할 수 있다는 걸 알게 되었다)
    - **단일 작업(Single Operation):** 데이터베이스에서 단 한 건의 레코드를 INSERT하거나 UPDATE할 때.
    - **성능 최적화(Performance):** 트랜잭션을 관리하는 오버헤드(잠금, 롤백 로그 등)를 없애기 위해 성능이 매우 중요한 쓰기 작업에 사용하지 않을 수 있음.
        - 단, 오토 커밋 방식은 대량 작업 시 오히려 느릴 수 있음.
    - **로그성 데이터 저장:** 시스템 로그, 방문자 수 기록 등 데이터가 일부 손실되어도 서비스 무결성에 영향을 주지 않는 데이터를 저장할 때
    - **비결정적/보조적 데이터:** 메인 비즈니스 로직(예: 계좌이체)의 일부가 아닌, 나중에 반영되어도 상관없는 보조 정보(예: 통계 데이터 갱신)를 저장할 때

<br>

## 테스트 및 검증 내용
> 어떻게 테스트했고, 어떤 결과를 확인했는지 적어주세요.

Jest 테스트 코드 실행.
개발 환경에서 pnpm run dev 실행.

<br>

## 🤔 주요 고민과 해결 과정

- [category.service 성능 개선하기](https://www.notion.so/Category-service-313b3b04c381804a9d93e61135ccb16b?source=copy_link)

<br>

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<br>

## 🧩 참고 사항 (선택)

[nest.js의 트랜잭션 데코레이터 추상화하기](https://l4279625.tistory.com/158)