### PR TITLE
google 모듈 리팩터링

### DIFF
--- a/apps/backend/src/modules/google/google.constants.ts
+++ b/apps/backend/src/modules/google/google.constants.ts
@@ -1,0 +1,60 @@
+export const GOOGLE_PLACES_API = {
+  BASE_URL: 'https://places.googleapis.com/v1',
+  TIMEOUT_MS: 10000,
+  LANGUAGE_CODE: 'ko',
+} as const
+
+export const GOOGLE_PLACE_FIELD_MASKS = {
+  SEARCH: [
+    'places.id',
+    'places.displayName',
+    'places.formattedAddress',
+    'places.location',
+    'places.rating',
+    'places.userRatingCount',
+    'places.photos',
+    'places.reviews',
+    'places.regularOpeningHours',
+    'places.priceLevel',
+    'places.priceRange',
+    'places.nationalPhoneNumber',
+    'places.websiteUri',
+    'places.types',
+    'places.primaryType',
+    'places.primaryTypeDisplayName',
+    'places.parkingOptions',
+    'places.reservable',
+    'places.allowsDogs',
+    'nextPageToken',
+  ].join(','),
+  DETAILS: [
+    'id',
+    'displayName',
+    'formattedAddress',
+    'location',
+    'rating',
+    'userRatingCount',
+    'photos',
+    'reviews',
+    'regularOpeningHours',
+    'priceRange',
+    'nationalPhoneNumber',
+    'websiteUri',
+    'types',
+    'primaryType',
+    'primaryTypeDisplayName',
+    'parkingOptions',
+    'reservable',
+    'allowsDogs',
+  ].join(','),
+} as const
+
+export const GOOGLE_SEARCH_DEFAULTS = {
+  MAX_RESULT_COUNT: 20,
+  RADIUS_METERS: 2000,
+} as const
+
+export const GOOGLE_PHOTO_DEFAULTS = {
+  MAX_WIDTH_PX: 400,
+  MAX_HEIGHT_PX: 400,
+} as const

--- a/apps/backend/src/modules/google/google.controller.spec.ts
+++ b/apps/backend/src/modules/google/google.controller.spec.ts
@@ -52,6 +52,18 @@ describe('GoogleController', () => {
       expect(service.searchText).toHaveBeenCalledWith(dto)
       expect(result).toEqual(expectedResult)
     })
+
+    it('roomId 없이 searchText를 호출할 수 있다', async () => {
+      const dto = { textQuery: 'test' }
+      const expectedResult = { places: [] }
+
+      service.searchText.mockResolvedValue(expectedResult)
+
+      const result = await controller.searchText(dto)
+
+      expect(service.searchText).toHaveBeenCalledWith(dto)
+      expect(result).toEqual(expectedResult)
+    })
   })
 
   describe('getPlaceDetails', () => {

--- a/apps/backend/src/modules/google/google.controller.spec.ts
+++ b/apps/backend/src/modules/google/google.controller.spec.ts
@@ -78,7 +78,7 @@ describe('GoogleController', () => {
 
       const result = await controller.getPhoto(placeId, photoId)
 
-      expect(service.getPhoto).toHaveBeenCalledWith(`places/${placeId}/photos/${photoId}`, 400, 400)
+      expect(service.getPhoto).toHaveBeenCalledWith(placeId, photoId, undefined, undefined)
       expect(result).toEqual(expectedResult)
     })
 
@@ -93,7 +93,7 @@ describe('GoogleController', () => {
 
       await controller.getPhoto(placeId, photoId, maxWidth, maxHeight)
 
-      expect(service.getPhoto).toHaveBeenCalledWith(`places/${placeId}/photos/${photoId}`, maxWidth, maxHeight)
+      expect(service.getPhoto).toHaveBeenCalledWith(placeId, photoId, maxWidth, maxHeight)
     })
   })
 })

--- a/apps/backend/src/modules/google/google.controller.ts
+++ b/apps/backend/src/modules/google/google.controller.ts
@@ -64,7 +64,6 @@ export class GoogleController {
     @Query('maxWidthPx') maxWidthPx?: number,
     @Query('maxHeightPx') maxHeightPx?: number,
   ): Promise<{ photoUri: string }> {
-    const photoName = `places/${placeId}/photos/${photoId}`
-    return this.googleService.getPhoto(photoName, maxWidthPx || 400, maxHeightPx || 400)
+    return this.googleService.getPhoto(placeId, photoId, maxWidthPx, maxHeightPx)
   }
 }

--- a/apps/backend/src/modules/google/google.service.spec.ts
+++ b/apps/backend/src/modules/google/google.service.spec.ts
@@ -142,7 +142,9 @@ describe('GoogleService', () => {
   })
 
   describe('getPhoto', () => {
-    const photoName = 'places/place-1/photos/photo-1'
+    const placeId = 'place-1'
+    const photoId = 'photo-1'
+    const photoName = `places/${placeId}/photos/${photoId}`
 
     it('API 호출이 성공하면 photoUri를 반환해야 한다', async () => {
       const mockPhotoUri = 'https://lh3.googleusercontent.com/places/...'
@@ -151,7 +153,7 @@ describe('GoogleService', () => {
         data: { photoUri: mockPhotoUri },
       })
 
-      const result = await service.getPhoto(photoName)
+      const result = await service.getPhoto(placeId, photoId)
 
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         `/${photoName}/media`,
@@ -167,7 +169,7 @@ describe('GoogleService', () => {
       const errorResponse = { response: { status: 403 } }
       mockAxiosInstance.get.mockRejectedValue(errorResponse)
 
-      await expect(service.getPhoto(photoName)).rejects.toThrow(new CustomException(ErrorType.Unauthorized, 'Google API 인증 실패'))
+      await expect(service.getPhoto(placeId, photoId)).rejects.toThrow(new CustomException(ErrorType.Unauthorized, 'Google API 인증 실패'))
     })
   })
 })

--- a/apps/backend/src/modules/google/google.service.spec.ts
+++ b/apps/backend/src/modules/google/google.service.spec.ts
@@ -147,24 +147,25 @@ describe('GoogleService', () => {
     it('API 호출이 성공하면 photoUri를 반환해야 한다', async () => {
       const mockPhotoUri = 'https://lh3.googleusercontent.com/places/...'
 
-      // getPhoto 메서드는 정적 axios.get을 사용하므로 이를 모킹
-      ;(axios.get as jest.Mock).mockResolvedValue({
+      mockAxiosInstance.get.mockResolvedValue({
         data: { photoUri: mockPhotoUri },
       })
 
       const result = await service.getPhoto(photoName)
 
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(axios.get as jest.Mock).toHaveBeenCalledWith(expect.stringContaining(photoName))
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+        `/${photoName}/media`,
+        expect.objectContaining({
+          params: { maxWidthPx: 400, maxHeightPx: 400, skipHttpRedirect: true },
+        }),
+      )
 
-      expect(result).toEqual({
-        photoUri: mockPhotoUri,
-      })
+      expect(result).toEqual({ photoUri: mockPhotoUri })
     })
 
     it('API 호출 실패 시 예외를 처리해야 한다', async () => {
       const errorResponse = { response: { status: 403 } }
-      ;(axios.get as jest.Mock).mockRejectedValue(errorResponse)
+      mockAxiosInstance.get.mockRejectedValue(errorResponse)
 
       await expect(service.getPhoto(photoName)).rejects.toThrow(new CustomException(ErrorType.Unauthorized, 'Google API 인증 실패'))
     })

--- a/apps/backend/src/modules/google/google.service.spec.ts
+++ b/apps/backend/src/modules/google/google.service.spec.ts
@@ -123,11 +123,8 @@ describe('GoogleService', () => {
       const result = await service.searchText(dtoWithoutRoom)
 
       expect(mockRoomRepository.findById).not.toHaveBeenCalled()
-      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
-        '/places:searchText',
-        expect.not.objectContaining({ locationBias: expect.anything() }) as Record<string, unknown>,
-        expect.any(Object) as unknown,
-      )
+      const callArg = (mockAxiosInstance.post.mock.calls[0] as [string, Record<string, unknown>])[1]
+      expect(callArg).not.toHaveProperty('locationBias')
       expect(result.places).toHaveLength(1)
     })
 

--- a/apps/backend/src/modules/google/google.service.spec.ts
+++ b/apps/backend/src/modules/google/google.service.spec.ts
@@ -113,6 +113,39 @@ describe('GoogleService', () => {
 
       await expect(service.searchText(dto)).rejects.toThrow(new CustomException(ErrorType.BadRequest, '잘못된 요청입니다: Bad Request'))
     })
+
+    it('roomId가 없으면 locationBias 없이 검색해야 한다', async () => {
+      const dtoWithoutRoom = { textQuery: '맛집' }
+      mockAxiosInstance.post.mockResolvedValue({
+        data: { places: [{ id: 'place-1' }] },
+      })
+
+      const result = await service.searchText(dtoWithoutRoom)
+
+      expect(mockRoomRepository.findById).not.toHaveBeenCalled()
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/places:searchText',
+        expect.not.objectContaining({ locationBias: expect.anything() }) as Record<string, unknown>,
+        expect.any(Object) as unknown,
+      )
+      expect(result.places).toHaveLength(1)
+    })
+
+    it('pageToken이 있으면 requestBody에 포함해야 한다', async () => {
+      const dtoWithPageToken = { textQuery: '맛집', roomId: 'room-1', pageToken: 'next-page-token' }
+      mockRoomRepository.findById.mockResolvedValue({ x: 127.0, y: 37.0 })
+      mockAxiosInstance.post.mockResolvedValue({
+        data: { places: [] },
+      })
+
+      await service.searchText(dtoWithPageToken)
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/places:searchText',
+        expect.objectContaining({ pageToken: 'next-page-token' }) as Record<string, unknown>,
+        expect.any(Object) as unknown,
+      )
+    })
   })
 
   describe('getPlaceDetails', () => {
@@ -170,6 +203,17 @@ describe('GoogleService', () => {
       mockAxiosInstance.get.mockRejectedValue(errorResponse)
 
       await expect(service.getPhoto(placeId, photoId)).rejects.toThrow(new CustomException(ErrorType.Unauthorized, 'Google API 인증 실패'))
+    })
+  })
+
+  describe('handleError (non-axios error)', () => {
+    it('Axios 에러가 아닌 일반 에러는 BadGateway를 던져야 한다', async () => {
+      mockAxiosInstance.post.mockRejectedValue(new Error('unexpected'))
+      ;(axios.isAxiosError as unknown as jest.Mock).mockReturnValue(false)
+
+      await expect(service.searchText({ textQuery: '맛집' })).rejects.toThrow(
+        new CustomException(ErrorType.BadGateway, 'Google API 호출 중 오류 발생'),
+      )
     })
   })
 })

--- a/apps/backend/src/modules/google/google.service.ts
+++ b/apps/backend/src/modules/google/google.service.ts
@@ -138,12 +138,16 @@ export class GoogleService {
 
   async getPhoto(photoName: string, maxWidthPx = 400, maxHeightPx = 400): Promise<{ photoUri: string }> {
     try {
-      const url = `https://places.googleapis.com/v1/${photoName}/media?maxWidthPx=${maxWidthPx}&maxHeightPx=${maxHeightPx}&skipHttpRedirect=true&key=${this.apiKey}`
-
-      const response = await axios.get<{ photoUri: string }>(url)
+      const { data } = await this.axiosInstance.get<{ photoUri: string }>(`/${photoName}/media`, {
+        params: {
+          maxWidthPx,
+          maxHeightPx,
+          skipHttpRedirect: true,
+        },
+      })
 
       return {
-        photoUri: response.data.photoUri,
+        photoUri: data.photoUri,
       }
     } catch (error) {
       this.handleError(error)

--- a/apps/backend/src/modules/google/google.service.ts
+++ b/apps/backend/src/modules/google/google.service.ts
@@ -5,7 +5,7 @@ import { ConfigService } from '@nestjs/config'
 import axios, { AxiosInstance } from 'axios'
 import { SearchTextDto, PlaceDetailsDto, GoogleSearchResponseDto, GooglePlaceDto } from './dto'
 import { RoomRepository } from '@/modules/room/room.repository'
-import { GOOGLE_PLACES_API, GOOGLE_PLACE_FIELD_MASKS, GOOGLE_PHOTO_DEFAULTS } from './google.constants'
+import { GOOGLE_PLACES_API, GOOGLE_PLACE_FIELD_MASKS, GOOGLE_PHOTO_DEFAULTS, GOOGLE_SEARCH_DEFAULTS } from './google.constants'
 
 @Injectable()
 export class GoogleService {
@@ -20,7 +20,7 @@ export class GoogleService {
 
     this.axiosInstance = axios.create({
       baseURL: GOOGLE_PLACES_API.BASE_URL,
-      timeout: 10000,
+      timeout: GOOGLE_PLACES_API.TIMEOUT_MS,
       headers: {
         'Content-Type': 'application/json',
         'X-Goog-Api-Key': this.apiKey,
@@ -44,15 +44,15 @@ export class GoogleService {
 
       const requestBody: Record<string, unknown> = {
         textQuery: dto.textQuery,
-        languageCode: 'ko',
-        maxResultCount: dto.maxResultCount ?? 20,
+        languageCode: GOOGLE_PLACES_API.LANGUAGE_CODE,
+        maxResultCount: dto.maxResultCount ?? GOOGLE_SEARCH_DEFAULTS.MAX_RESULT_COUNT,
       }
 
       if (latitude !== undefined && longitude !== undefined) {
         requestBody.locationBias = {
           circle: {
             center: { latitude, longitude },
-            radius: dto.radius ?? 2000,
+            radius: dto.radius ?? GOOGLE_SEARCH_DEFAULTS.RADIUS_METERS,
           },
         }
       }
@@ -87,7 +87,7 @@ export class GoogleService {
           'X-Goog-FieldMask': fieldMask,
         },
         params: {
-          languageCode: 'ko',
+          languageCode: GOOGLE_PLACES_API.LANGUAGE_CODE,
         },
       })
 
@@ -97,8 +97,14 @@ export class GoogleService {
     }
   }
 
-  async getPhoto(photoName: string, maxWidthPx = 400, maxHeightPx = 400): Promise<{ photoUri: string }> {
+  async getPhoto(
+    placeId: string,
+    photoId: string,
+    maxWidthPx: number = GOOGLE_PHOTO_DEFAULTS.MAX_WIDTH_PX,
+    maxHeightPx: number = GOOGLE_PHOTO_DEFAULTS.MAX_HEIGHT_PX,
+  ): Promise<{ photoUri: string }> {
     try {
+      const photoName = `places/${placeId}/photos/${photoId}`
       const { data } = await this.axiosInstance.get<{ photoUri: string }>(`/${photoName}/media`, {
         params: {
           maxWidthPx,

--- a/apps/backend/src/modules/google/google.service.ts
+++ b/apps/backend/src/modules/google/google.service.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '@nestjs/config'
 import axios, { AxiosInstance } from 'axios'
 import { SearchTextDto, PlaceDetailsDto, GoogleSearchResponseDto, GooglePlaceDto } from './dto'
 import { RoomRepository } from '@/modules/room/room.repository'
+import { GOOGLE_PLACES_API, GOOGLE_PLACE_FIELD_MASKS, GOOGLE_PHOTO_DEFAULTS } from './google.constants'
 
 @Injectable()
 export class GoogleService {
@@ -18,7 +19,7 @@ export class GoogleService {
     this.apiKey = this.configService.getOrThrow<string>('GOOGLE_MAPS_API_KEY')
 
     this.axiosInstance = axios.create({
-      baseURL: 'https://places.googleapis.com/v1',
+      baseURL: GOOGLE_PLACES_API.BASE_URL,
       timeout: 10000,
       headers: {
         'Content-Type': 'application/json',
@@ -60,28 +61,7 @@ export class GoogleService {
         requestBody.pageToken = dto.pageToken
       }
 
-      const fieldMask = [
-        'places.id',
-        'places.displayName',
-        'places.formattedAddress',
-        'places.location',
-        'places.rating',
-        'places.userRatingCount',
-        'places.photos',
-        'places.reviews',
-        'places.regularOpeningHours',
-        'places.priceLevel',
-        'places.priceRange',
-        'places.nationalPhoneNumber',
-        'places.websiteUri',
-        'places.types',
-        'places.primaryType',
-        'places.primaryTypeDisplayName',
-        'places.parkingOptions',
-        'places.reservable',
-        'places.allowsDogs',
-        'nextPageToken',
-      ].join(',')
+      const fieldMask = GOOGLE_PLACE_FIELD_MASKS.SEARCH
 
       const { data } = await this.axiosInstance.post<GoogleSearchResponseDto>('/places:searchText', requestBody, {
         headers: {
@@ -100,26 +80,7 @@ export class GoogleService {
 
   async getPlaceDetails(dto: PlaceDetailsDto): Promise<GooglePlaceDto> {
     try {
-      const fieldMask = [
-        'id',
-        'displayName',
-        'formattedAddress',
-        'location',
-        'rating',
-        'userRatingCount',
-        'photos',
-        'reviews',
-        'regularOpeningHours',
-        'priceRange',
-        'nationalPhoneNumber',
-        'websiteUri',
-        'types',
-        'primaryType',
-        'primaryTypeDisplayName',
-        'parkingOptions',
-        'reservable',
-        'allowsDogs',
-      ].join(',')
+      const fieldMask = GOOGLE_PLACE_FIELD_MASKS.DETAILS
 
       const { data } = await this.axiosInstance.get<GooglePlaceDto>(`/places/${dto.placeId}`, {
         headers: {


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
> - Closes #437 


<br>

## 📝 작업 내용
- `getphoto`에서 axios를 호출하는 방식 수정
  - `axiosInstance`를 이용
- fieldMask 상수화
- 매직 넘버, 하드 코딩된 값 정리
- controller에 포함된 비즈니스 로직을 service로 이전
- 테스트 커버리지 향상


<br>

## 🖼️ 스크린샷 (선택)

<img width="1419" height="137" alt="스크린샷 2026-02-27 오전 1 52 33" src="https://github.com/user-attachments/assets/89581781-f95b-43af-b6e0-a2aaf7a41813" />
<img width="1911" height="137" alt="스크린샷 2026-02-27 오전 1 41 34" src="https://github.com/user-attachments/assets/7c75c3a5-f86b-4aab-b6e1-75c91a4ac781" />

<br>

## 테스트 및 검증 내용
> Jest 테스트


<br>

## 🤔 주요 고민과 해결 과정

- [Google 모듈 리팩터링](https://www.notion.so/Google-31337262a179805aafadcfdec275b685?source=copy_link)