### PR TITLE
Vote 모듈 리팩터링

### DIFF
--- a/apps/backend/src/modules/vote/vote.controller.spec.ts
+++ b/apps/backend/src/modules/vote/vote.controller.spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { VoteController } from './vote.controller'
+import { VoteService } from './vote.service'
+import { VoteCandidate } from './vote.types'
+
+describe('VoteController', () => {
+  let controller: VoteController
+
+  const voteService = {
+    getVoteResults: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [VoteController],
+      providers: [{ provide: VoteService, useValue: voteService }],
+    }).compile()
+
+    controller = module.get<VoteController>(VoteController)
+  })
+
+  describe('getVoteResults', () => {
+    it('roomId로 투표 결과를 조회하고 결과를 반환한다', async () => {
+      const roomId = 'room-1'
+      const mockResults: VoteCandidate[] = [
+        {
+          category: '음식점',
+          result: [
+            {
+              placeId: 'place-1',
+              name: '카페 A',
+              address: '서울시 강남구',
+              createdBy: 'user-1',
+              createdAt: new Date(),
+            },
+          ],
+        },
+      ]
+
+      voteService.getVoteResults.mockResolvedValue(mockResults)
+
+      const result = await controller.getVoteResults(roomId)
+
+      expect(voteService.getVoteResults).toHaveBeenCalledTimes(1)
+      expect(voteService.getVoteResults).toHaveBeenCalledWith(roomId)
+      expect(result).toEqual(mockResults)
+    })
+
+    it('결과가 없으면 빈 배열을 반환한다', async () => {
+      const roomId = 'room-1'
+
+      voteService.getVoteResults.mockResolvedValue([])
+
+      const result = await controller.getVoteResults(roomId)
+
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/apps/backend/src/modules/vote/vote.controller.ts
+++ b/apps/backend/src/modules/vote/vote.controller.ts
@@ -1,81 +1,18 @@
-import { CustomException } from '@/lib/exceptions/custom.exception'
-import { VoteSession, VoteStatus, Candidate, VoteCandidate } from '@/modules/vote/vote.types'
+import { VoteCandidate } from '@/modules/vote/vote.types'
 import { Controller, Get, Param } from '@nestjs/common'
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger'
 import { VoteService } from './vote.service'
-import { CategoryService } from '@/modules/category/category.service'
 
 @ApiTags('vote')
 @Controller('vote')
 export class VoteController {
-  constructor(
-    private readonly voteService: VoteService,
-    private readonly categoryService: CategoryService,
-  ) {}
+  constructor(private readonly voteService: VoteService) {}
 
   @Get('/results/:roomId')
   @ApiOperation({ summary: '투표 최종 결과 조회', description: 'Room 내 모든 카테고리의 투표 최종 결과를 조회합니다.' })
   @ApiParam({ name: 'roomId', description: '룸 ID' })
   @ApiResponse({ status: 200, description: '카테고리별 투표 결과 목록' })
   async getVoteResults(@Param('roomId') roomId: string): Promise<VoteCandidate[]> {
-    const categories = await this.categoryService.findByRoomId(roomId)
-    const results: VoteCandidate[] = []
-
-    for (const category of categories) {
-      const voteRoomId = `${roomId}:${category.id}`
-      let session: VoteSession
-
-      try {
-        session = this.voteService.getSessionOrThrow(voteRoomId)
-      } catch (e) {
-        if (e instanceof CustomException) {
-          continue
-        }
-        throw e
-      }
-
-      if (session.status !== VoteStatus.COMPLETED) {
-        continue
-      }
-
-      const { candidates, totalCounts, selectedCandidateId } = session
-      if (candidates.size === 0) continue
-
-      // 방장 최종 선택이 있는 경우 해당 후보만 반환
-      if (selectedCandidateId) {
-        const selected = candidates.get(selectedCandidateId)
-        if (selected) {
-          results.push({
-            category: category.title,
-            result: [selected],
-          })
-          continue
-        }
-        // selectedCandidateId가 유효하지 않으면 기존 집계 로직으로 폴백
-      }
-
-      let maxVotes = 0
-      for (const count of totalCounts.values()) {
-        if (count >= maxVotes) {
-          maxVotes = count
-        }
-      }
-
-      if (maxVotes === 0) continue
-
-      const winners: Candidate[] = []
-      for (const candidate of candidates.values()) {
-        if ((totalCounts.get(candidate.placeId) ?? 0) === maxVotes) {
-          winners.push(candidate)
-        }
-      }
-
-      results.push({
-        category: category.title,
-        result: winners,
-      })
-    }
-
-    return results
+    return this.voteService.getVoteResults(roomId)
   }
 }

--- a/apps/backend/src/modules/vote/vote.gateway.spec.ts
+++ b/apps/backend/src/modules/vote/vote.gateway.spec.ts
@@ -206,6 +206,37 @@ describe('VoteGateway', () => {
     })
   })
 
+  describe('onVoteJoin (error cases)', () => {
+    it('user가 없으면 예외를 던진다', async () => {
+      const client = {
+        join: jest.fn(),
+        emit: jest.fn(),
+        data: {},
+        id: 'socket-1',
+      } as unknown as Socket
+      const payload: VoteJoinPayload = { roomId: 'room-1', categoryId: 'category-1' }
+
+      userService.getSession.mockReturnValue(null)
+
+      await expect(gateway.onVoteJoin(client, payload)).rejects.toThrow(CustomException)
+    })
+
+    it('user.roomId가 payload.roomId와 다르면 예외를 던진다', async () => {
+      const client = {
+        join: jest.fn(),
+        emit: jest.fn(),
+        data: {},
+        id: 'socket-1',
+      } as unknown as Socket
+      const payload: VoteJoinPayload = { roomId: 'room-1', categoryId: 'category-1' }
+      const wrongRoomUser = { userId: 'user-1', name: 'user', socketId: 'socket-1', roomId: 'room-2', isOwner: false }
+
+      userService.getSession.mockReturnValue(wrongRoomUser)
+
+      await expect(gateway.onVoteJoin(client, payload)).rejects.toThrow(CustomException)
+    })
+  })
+
   describe('onVoteLeave', () => {
     it('클라이언트를 투표 룸에서 떠나게 한다', async () => {
       const leaveMock = jest.fn<Promise<void>, [string]>().mockResolvedValue(undefined)
@@ -233,9 +264,50 @@ describe('VoteGateway', () => {
       expect(leaveMock).toHaveBeenCalledTimes(1)
       expect(leaveMock).toHaveBeenCalledWith(`vote:${voteRoomId}`)
     })
+
+    it('user가 없으면 예외를 던진다', async () => {
+      const client = {
+        leave: jest.fn(),
+        id: 'socket-1',
+      } as unknown as Socket
+      const payload: VoteLeavePayload = { roomId: 'room-1', categoryId: 'category-1' }
+
+      userService.getSession.mockReturnValue(null)
+
+      await expect(gateway.onVoteLeave(client, payload)).rejects.toThrow(CustomException)
+    })
+
+    it('user.roomId가 payload.roomId와 다르면 예외를 던진다', async () => {
+      const client = {
+        leave: jest.fn(),
+        id: 'socket-1',
+      } as unknown as Socket
+      const payload: VoteLeavePayload = { roomId: 'room-1', categoryId: 'category-1' }
+      const wrongRoomUser = { userId: 'user-1', name: 'user', socketId: 'socket-1', roomId: 'room-2', isOwner: false }
+
+      userService.getSession.mockReturnValue(wrongRoomUser)
+
+      await expect(gateway.onVoteLeave(client, payload)).rejects.toThrow(CustomException)
+    })
   })
 
   describe('onCandidateAdd', () => {
+    it('user가 없으면 예외를 던진다', () => {
+      const client = { id: 'socket-1' } as Socket
+      const payload: VoteCandidateAddPayload = {
+        roomId: 'room-1',
+        categoryId: 'category-1',
+        placeId: 'place-1',
+        name: '카페',
+        address: '서울시 강남구',
+      }
+
+      userService.getSession.mockReturnValue(null)
+
+      expect(() => gateway.onCandidateAdd(client, payload)).toThrow(CustomException)
+      expect(voteService.addCandidatePlace).not.toHaveBeenCalled()
+    })
+
     it('후보를 추가하고 브로드캐스터로 업데이트를 전송한다', () => {
       const client = {
         id: 'socket-1',
@@ -278,6 +350,20 @@ describe('VoteGateway', () => {
   })
 
   describe('onCandidateRemove', () => {
+    it('user가 없으면 예외를 던진다', () => {
+      const client = { id: 'socket-1' } as Socket
+      const payload: VoteCandidateRemovePayload = {
+        roomId: 'room-1',
+        categoryId: 'category-1',
+        candidateId: 'candidate-1',
+      }
+
+      userService.getSession.mockReturnValue(null)
+
+      expect(() => gateway.onCandidateRemove(client, payload)).toThrow(CustomException)
+      expect(voteService.removeCandidatePlace).not.toHaveBeenCalled()
+    })
+
     it('후보를 제거하고 브로드캐스터로 업데이트를 전송한다', () => {
       const client = {
         id: 'socket-1',
@@ -288,10 +374,18 @@ describe('VoteGateway', () => {
         candidateId: 'candidate-1',
       }
       const voteRoomId = 'room-1:category-1'
+      const mockUser = {
+        userId: 'user-1',
+        name: 'user',
+        socketId: 'socket-1',
+        roomId: 'room-1',
+        isOwner: false,
+      }
       const mockRemovedPayload = {
         candidate: { placeId: 'candidate-1', name: '카페', address: '서울', createdBy: 'user-1', createdAt: new Date() },
       }
 
+      userService.getSession.mockReturnValue(mockUser)
       voteService.removeCandidatePlace.mockReturnValue(mockRemovedPayload)
 
       gateway.onCandidateRemove(client, payload)

--- a/apps/backend/src/modules/vote/vote.service.spec.ts
+++ b/apps/backend/src/modules/vote/vote.service.spec.ts
@@ -6,6 +6,9 @@ import { VoteSessionStore } from './vote-session.store'
 import { VoteStatus, PlaceData } from './vote.types'
 import { CategoryService } from '@/modules/category/category.service'
 
+// CategoryService mock 객체 (getVoteResults 테스트에서 재사용)
+let mockCategoryService: { findByRoomId: jest.Mock }
+
 // 테스트용 더미 데이터
 const mockPlaceData: PlaceData = {
   placeId: 'place-123',
@@ -22,8 +25,10 @@ describe('VoteService', () => {
   const userId2 = 'user-2'
 
   beforeEach(async () => {
+    mockCategoryService = { findByRoomId: jest.fn() }
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [VoteService, VoteSessionStore, { provide: CategoryService, useValue: { findByRoomId: jest.fn() } }],
+      providers: [VoteService, VoteSessionStore, { provide: CategoryService, useValue: mockCategoryService }],
     }).compile()
 
     service = module.get<VoteService>(VoteService)
@@ -54,6 +59,31 @@ describe('VoteService', () => {
 
       // getSessionOrThrow 호출 시 예외 발생해야 함
       expect(() => service.getSessionOrThrow(roomId)).toThrow(CustomException)
+    })
+  })
+
+  describe('deleteSessionsByRoom', () => {
+    it('해당 방의 모든 카테고리 세션을 삭제한다', () => {
+      const baseRoomId = 'room-1'
+      service.getOrCreateSession(`${baseRoomId}:cat-1`, userId)
+      service.getOrCreateSession(`${baseRoomId}:cat-2`, userId)
+      service.getOrCreateSession('room-2:cat-1', userId) // 다른 방
+
+      service.deleteSessionsByRoom(baseRoomId)
+
+      expect(() => service.getSessionOrThrow(`${baseRoomId}:cat-1`)).toThrow(CustomException)
+      expect(() => service.getSessionOrThrow(`${baseRoomId}:cat-2`)).toThrow(CustomException)
+      // 다른 방의 세션은 유지
+      expect(() => service.getSessionOrThrow('room-2:cat-1')).not.toThrow()
+    })
+
+    it('해당하는 세션이 없으면 아무것도 삭제하지 않는다', () => {
+      service.getOrCreateSession('room-2:cat-1', userId)
+
+      service.deleteSessionsByRoom('room-1')
+
+      // room-2의 세션은 유지
+      expect(() => service.getSessionOrThrow('room-2:cat-1')).not.toThrow()
     })
   })
 
@@ -525,6 +555,132 @@ describe('VoteService', () => {
       expect(() => {
         service.resetVote(roomId)
       }).toThrow(CustomException)
+    })
+
+    it('OWNER_PICK 상태에서는 리셋할 수 없다', () => {
+      // OWNER_PICK은 COMPLETED가 아니므로 리셋 불가
+      expect(() => {
+        service.resetVote(roomId)
+      }).toThrow(CustomException)
+
+      try {
+        service.resetVote(roomId)
+      } catch (e) {
+        expect((e as CustomException).type).toBe(ErrorType.BadRequest)
+      }
+    })
+  })
+
+  describe('getWinnerCandidates', () => {
+    const voteRoomId = 'room-1:cat-1'
+
+    beforeEach(() => {
+      service.getOrCreateSession(voteRoomId, userId)
+      service.addCandidatePlace(voteRoomId, userId, mockPlaceData)
+    })
+
+    it('세션이 없으면 빈 배열을 반환한다', () => {
+      const result = service.getWinnerCandidates('non-existent')
+      expect(result).toEqual([])
+    })
+
+    it('COMPLETED 상태가 아니면 빈 배열을 반환한다', () => {
+      // WAITING 상태
+      const result = service.getWinnerCandidates(voteRoomId)
+      expect(result).toEqual([])
+    })
+
+    it('득표수가 0이면 빈 배열을 반환한다 (투표 없이 종료)', () => {
+      const session = service.getSessionOrThrow(voteRoomId)
+      session.status = VoteStatus.COMPLETED
+
+      const result = service.getWinnerCandidates(voteRoomId)
+      expect(result).toEqual([])
+    })
+
+    it('selectedCandidateId가 있으면 해당 후보만 반환한다', () => {
+      const session = service.getSessionOrThrow(voteRoomId)
+      session.status = VoteStatus.COMPLETED
+      session.selectedCandidateId = mockPlaceData.placeId
+
+      const result = service.getWinnerCandidates(voteRoomId)
+      expect(result).toHaveLength(1)
+      expect(result[0].placeId).toBe(mockPlaceData.placeId)
+    })
+
+    it('최다 득표 후보를 반환한다', () => {
+      const place2: PlaceData = { ...mockPlaceData, placeId: 'place-456' }
+      service.addCandidatePlace(voteRoomId, userId, place2)
+      service.startVote(voteRoomId)
+
+      service.castVote(voteRoomId, userId, mockPlaceData.placeId)
+      service.castVote(voteRoomId, userId2, mockPlaceData.placeId)
+      service.castVote(voteRoomId, userId2, place2.placeId)
+      service.endVote(voteRoomId)
+
+      const result = service.getWinnerCandidates(voteRoomId)
+      expect(result).toHaveLength(1)
+      expect(result[0].placeId).toBe(mockPlaceData.placeId)
+    })
+
+    it('동점자가 있으면 모두 반환한다', () => {
+      const place2: PlaceData = { ...mockPlaceData, placeId: 'place-456' }
+      service.addCandidatePlace(voteRoomId, userId, place2)
+      service.startVote(voteRoomId)
+
+      // 1표씩 동점
+      service.castVote(voteRoomId, userId, mockPlaceData.placeId)
+      service.castVote(voteRoomId, userId2, place2.placeId)
+
+      const session = service.getSessionOrThrow(voteRoomId)
+      session.status = VoteStatus.COMPLETED
+
+      const result = service.getWinnerCandidates(voteRoomId)
+      expect(result).toHaveLength(2)
+    })
+  })
+
+  describe('getVoteResults', () => {
+    it('카테고리별 투표 결과를 반환한다', async () => {
+      const baseRoomId = 'room-1'
+      const categoryId = 'cat-1'
+      const voteRoomId = `${baseRoomId}:${categoryId}`
+
+      // 투표 세션 설정 및 투표 종료
+      service.getOrCreateSession(voteRoomId, userId)
+      service.addCandidatePlace(voteRoomId, userId, mockPlaceData)
+      service.startVote(voteRoomId)
+      service.castVote(voteRoomId, userId, mockPlaceData.placeId)
+      service.endVote(voteRoomId)
+
+      mockCategoryService.findByRoomId.mockResolvedValue([{ id: categoryId, title: '음식점' }])
+
+      const result = await service.getVoteResults(baseRoomId)
+
+      expect(mockCategoryService.findByRoomId).toHaveBeenCalledWith(baseRoomId)
+      expect(result).toHaveLength(1)
+      expect(result[0].category).toBe('음식점')
+      expect(result[0].result).toHaveLength(1)
+      expect(result[0].result[0].placeId).toBe(mockPlaceData.placeId)
+    })
+
+    it('승자가 없는 카테고리는 결과에서 제외된다', async () => {
+      const baseRoomId = 'room-1'
+
+      mockCategoryService.findByRoomId.mockResolvedValue([{ id: 'cat-1', title: '음식점' }])
+      // 해당 카테고리의 세션 없음 (getWinnerCandidates → [])
+
+      const result = await service.getVoteResults(baseRoomId)
+
+      expect(result).toEqual([])
+    })
+
+    it('카테고리가 없으면 빈 배열을 반환한다', async () => {
+      mockCategoryService.findByRoomId.mockResolvedValue([])
+
+      const result = await service.getVoteResults('room-1')
+
+      expect(result).toEqual([])
     })
   })
 

--- a/apps/backend/src/modules/vote/vote.service.spec.ts
+++ b/apps/backend/src/modules/vote/vote.service.spec.ts
@@ -4,6 +4,7 @@ import { ErrorType } from '@/lib/types/response.type'
 import { VoteService } from './vote.service'
 import { VoteSessionStore } from './vote-session.store'
 import { VoteStatus, PlaceData } from './vote.types'
+import { CategoryService } from '@/modules/category/category.service'
 
 // 테스트용 더미 데이터
 const mockPlaceData: PlaceData = {
@@ -22,7 +23,7 @@ describe('VoteService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [VoteService, VoteSessionStore],
+      providers: [VoteService, VoteSessionStore, { provide: CategoryService, useValue: { findByRoomId: jest.fn() } }],
     }).compile()
 
     service = module.get<VoteService>(VoteService)

--- a/apps/backend/src/modules/vote/vote.service.ts
+++ b/apps/backend/src/modules/vote/vote.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@nestjs/common'
 import { CustomException } from '@/lib/exceptions/custom.exception'
 import { ErrorType } from '@/lib/types/response.type'
-import { Candidate, PlaceData, VoteSession, VoteStatus } from './vote.types'
+import { Candidate, PlaceData, VoteCandidate, VoteSession, VoteStatus } from './vote.types'
 import { VoteSessionStore } from './vote-session.store'
+import { CategoryService } from '@/modules/category/category.service'
 import {
   VoteCandidateAddedPayload,
   VoteCandidateRemovedPayload,
@@ -20,7 +21,10 @@ import {
 @Injectable()
 export class VoteService {
   // categoryId : 투표 세션
-  constructor(private readonly sessions: VoteSessionStore) {}
+  constructor(
+    private readonly sessions: VoteSessionStore,
+    private readonly categoryService: CategoryService,
+  ) {}
 
   /**
    * 세션 생성 또는 조회 (vote:join)
@@ -573,14 +577,56 @@ export class VoteService {
   }
 
   /**
+   * 카테고리별 투표 최종 결과 조회 (GET /vote/results/:roomId)
+   * @param roomId 방 ID
+   */
+  async getVoteResults(roomId: string): Promise<VoteCandidate[]> {
+    const categories = await this.categoryService.findByRoomId(roomId)
+    const results: VoteCandidate[] = []
+
+    for (const category of categories) {
+      const voteRoomId = `${roomId}:${category.id}`
+      const session = this.sessions.get(voteRoomId)
+
+      if (!session || session.status !== VoteStatus.COMPLETED) continue
+      if (session.candidates.size === 0) continue
+
+      const { candidates, totalCounts, selectedCandidateId } = session
+
+      if (selectedCandidateId) {
+        const selected = candidates.get(selectedCandidateId)
+        if (selected) {
+          results.push({ category: category.title, result: [selected] })
+          continue
+        }
+      }
+
+      let maxVotes = 0
+      for (const count of totalCounts.values()) {
+        if (count >= maxVotes) maxVotes = count
+      }
+
+      if (maxVotes === 0) continue
+
+      const winners: Candidate[] = []
+      for (const candidate of candidates.values()) {
+        if ((totalCounts.get(candidate.placeId) ?? 0) === maxVotes) {
+          winners.push(candidate)
+        }
+      }
+
+      results.push({ category: category.title, result: winners })
+    }
+
+    return results
+  }
+
+  /**
    * 특정 방의 모든 카테고리에서 사용자의 투표를 취소
    * - room 연결 해제 시 호출됨
-   * - voteRoomId 규칙: `${roomId}:${categoryId}`
    * @param roomId 방 ID
    * @param userId 사용자 ID
-   * @returns voteRoomId별 변경된 투표 정보 (브로드캐스트용)
    */
-
   revokeAllVotesForUser(roomId: string, userId: string): Array<{ voteRoomId: string; payload: VoteParticipantLeftPayload }> {
     const results: Array<{ voteRoomId: string; payload: VoteParticipantLeftPayload }> = []
     const prefix = `${roomId}:`

--- a/apps/backend/src/modules/vote/vote.service.ts
+++ b/apps/backend/src/modules/vote/vote.service.ts
@@ -505,11 +505,9 @@ export class VoteService {
 
     for (const [userId, userVotes] of session.userVotes.entries()) {
       for (const candidateId of userVotes) {
-        if (!session.candidates.has(candidateId)) continue
-        if (!voters[candidateId]) {
-          voters[candidateId] = []
+        if (voters[candidateId]) {
+          voters[candidateId].push(userId)
         }
-        voters[candidateId].push(userId)
       }
     }
 
@@ -517,18 +515,8 @@ export class VoteService {
   }
 
   private getVoterIdsForCandidate(session: VoteSession, candidateId: string): string[] {
-    if (!session.candidates.has(candidateId)) {
-      return []
-    }
-
-    const voters: string[] = []
-    for (const [userId, userVotes] of session.userVotes.entries()) {
-      if (userVotes.has(candidateId)) {
-        voters.push(userId)
-      }
-    }
-
-    return voters
+    const voterMap = this.getVoterIdsByCandidate(session)
+    return voterMap[candidateId] ?? []
   }
 
   // TODO: 승자를 세션에 넣어 불필요한 계산을 개선할 여지가 있다.

--- a/apps/backend/src/modules/vote/vote.service.ts
+++ b/apps/backend/src/modules/vote/vote.service.ts
@@ -586,34 +586,9 @@ export class VoteService {
 
     for (const category of categories) {
       const voteRoomId = `${roomId}:${category.id}`
-      const session = this.sessions.get(voteRoomId)
+      const winners = this.getWinnerCandidates(voteRoomId)
 
-      if (!session || session.status !== VoteStatus.COMPLETED) continue
-      if (session.candidates.size === 0) continue
-
-      const { candidates, totalCounts, selectedCandidateId } = session
-
-      if (selectedCandidateId) {
-        const selected = candidates.get(selectedCandidateId)
-        if (selected) {
-          results.push({ category: category.title, result: [selected] })
-          continue
-        }
-      }
-
-      let maxVotes = 0
-      for (const count of totalCounts.values()) {
-        if (count >= maxVotes) maxVotes = count
-      }
-
-      if (maxVotes === 0) continue
-
-      const winners: Candidate[] = []
-      for (const candidate of candidates.values()) {
-        if ((totalCounts.get(candidate.placeId) ?? 0) === maxVotes) {
-          winners.push(candidate)
-        }
-      }
+      if (winners.length === 0) continue
 
       results.push({ category: category.title, result: winners })
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
> - Closes #451


<br>

## 📝 작업 내용
- Controller와 Service 관심사 분리
  - 비즈니스 로직은 Service에서만 담당
- 중복된 투표 계산 로직 제거
- 투표 후보 반환 시 매번 전체 후보를 반환(O(n))하는 문제 해결
- 테스트 커버리지 향상


<br>

## 🖼️ 스크린샷 (선택)
<img width="954" height="120" alt="스크린샷 2026-03-03 오전 1 11 08" src="https://github.com/user-attachments/assets/4af7b9e0-e514-4b57-9ee7-633fac619832" />
<img width="1917" height="120" alt="스크린샷 2026-03-04 오전 2 25 36" src="https://github.com/user-attachments/assets/1ad00915-cf14-43b7-b5fb-cec9f486d443" />



<br>

## 테스트 및 검증 내용
> Jest 테스트


<br>

## 🤔 주요 고민과 해결 과정

- [Vote 모듈 리팩터링](https://www.notion.so/Vote-31737262a17980cc8b0feaec72dd3f1c?source=copy_link)